### PR TITLE
(feat) Add milestone as a configurable option to determine mergeability.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 [![CircleCI](https://circleci.com/gh/jusx/mergeable.svg?style=shield)](https://circleci.com/gh/jusx/mergeable)
 # The Mergeable Bot
-A GitHub App that prevents merging of pull requests based on [configurations](#configuration):
+A GitHub App that prevents merging of pull requests based on [configurations](#configuration). Make your pull requests mergeable only when:
 
-- Prevent your pull requests from being mergeable when certain terms are in the **title** or **label**.
+- Certain terms are not in the **title** or **label**.
 
-- Prevent your pull requests from being mergeable when the **milestone** on the pull request does not match with what is configured.
+- The **milestone** on the pull request matches with what is configured.
 
-- Make your pull requests mergeable only when there are `n` number of **approved reviews** where `n` is configurable.
+- There are at least `n` number of **approved reviews**, where `n` is configurable.
 
 <blockquote>
 [Install it](https://github.com/apps/mergeable) or [deploy your own](#deploy-your-own)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,15 @@
 # The Mergeable Bot
 A GitHub App that prevents merging of pull requests based on [configurations](#configuration).
 
-This is a GitHub App built with [probot](https://github.com/probot/probot).
+- Prevent your pull requests from being mergeable when certain terms are in the **title** or **label**.
+
+- Prevent your pull requests from being mergeable when the **milestone** on the pull request does not match with what is configured.
+
+- Make your pull requests mergeable only when there are `n` number of **approved reviews** where `n` is configurable.
+
+<blockquote>
+Improve workflow. [Install it now!](https://github.com/apps/mergeable)
+</blockquote>
 
 ## Configuration
 By default the Mergeable configuration is as follows:
@@ -31,7 +39,10 @@ mergeable:
   label: 'wip|do not merge|experimental'
 
   # Regular expression to be tested on the title. Not mergeable when true.  
-  title: 'wip' #  
+  title: 'wip'
+
+  # Only mergeable when milestone is as specified below.
+  milestone: 'version 1'  
 ```
 
 ## Usage
@@ -56,3 +67,6 @@ And subscription to the following events:
 - [x] Pull request
 - [x] Pull request review comment
 - [x] Pull request review
+
+## About
+Mergeable Bot is a GitHub App built with [probot](https://github.com/probot/probot).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # The Mergeable Bot
-A GitHub App that prevents merging of pull requests based on [configurations](#configuration).
+A GitHub App that prevents merging of pull requests based on [configurations](#configuration):
 
 - Prevent your pull requests from being mergeable when certain terms are in the **title** or **label**.
 
@@ -8,8 +8,10 @@ A GitHub App that prevents merging of pull requests based on [configurations](#c
 - Make your pull requests mergeable only when there are `n` number of **approved reviews** where `n` is configurable.
 
 <blockquote>
-Improve workflow. [Install it now!](https://github.com/apps/mergeable)
+[Install it](https://github.com/apps/mergeable) or [deploy your own](#deploy-your-own)
 </blockquote>
+
+The Mergeable Bot is built with [probot](https://github.com/probot/probot).
 
 ## Configuration
 By default the Mergeable configuration is as follows:
@@ -60,6 +62,7 @@ This GitHub App requires these permissions & events:
 
 - Repository metadata - **Read & Write**
 - Pull requests - **Read Only**
+- Issues - **Read Only**
 - Single File - **Read-only**
  - Path: `.github/mergeable.yml`
 
@@ -67,6 +70,4 @@ And subscription to the following events:
 - [x] Pull request
 - [x] Pull request review comment
 - [x] Pull request review
-
-## About
-Mergeable Bot is a GitHub App built with [probot](https://github.com/probot/probot).
+- [x] Issues

--- a/__tests__/approvals.test.js
+++ b/__tests__/approvals.test.js
@@ -11,11 +11,6 @@ const createMockContext = (minimum, data) => {
 
   return {
     repo: jest.fn(),
-    payload: {
-      pull_request: {
-        number: 1
-      }
-    },
     github: {
       pullRequests: {
         getReviews: jest.fn().mockReturnValue({ data: data })
@@ -32,26 +27,26 @@ const config = (min) => {
 }
 
 test('that mergeable is true when less than minimum', async () => {
-  let validation = await approvals(createMockContext(1), config(2))
+  let validation = await approvals({ number: 1 }, createMockContext(1), config(2))
   expect(validation.mergeable).toBe(false)
 })
 
 test('that mergeable is true when the same as minimum', async () => {
-  let validation = await approvals(createMockContext(2), config(2))
+  let validation = await approvals({ number: 1 }, createMockContext(2), config(2))
   expect(validation.mergeable).toBe(true)
 })
 
 test('that mergeable is true when greater than minimum', async () => {
-  let validation = await approvals(createMockContext(3), config(2))
+  let validation = await approvals({ number: 1 }, createMockContext(3), config(2))
   expect(validation.mergeable).toBe(true)
 })
 
 test('that description is dynamic based on minimum', async () => {
-  let validation = await approvals(createMockContext(3), config(5))
+  let validation = await approvals({ number: 1 }, createMockContext(3), config(5))
   expect(validation.description).toBe('At least 5 review approval(s) required.')
 })
 
 test('that description is null when mergeable', async () => {
-  let validation = await approvals(createMockContext(5), config(5))
+  let validation = await approvals({ number: 1 }, createMockContext(5), config(5))
   expect(validation.description).toBe(null)
 })

--- a/__tests__/label.test.js
+++ b/__tests__/label.test.js
@@ -6,42 +6,43 @@ test('fail gracefully if invalid regex', async () => {
     mergeable:
       label: '@#$@#$@#$'
   `)
-  let validation = await label(createMock('WIP'), config.settings)
+  let validation = await label(createMockPR(), createMockContext('WIP'), config.settings)
   expect(validation.mergeable).toBe(true)
 })
 
 test('mergeable is false if regex found or true if not when there is only one label', async () => {
   let config = new Configuration()
 
-  let validation = await label(createMock('work in progress'), config.settings)
+  let validation = await label(createMockPR(), createMockContext('work in progress'), config.settings)
   expect(validation.mergeable).toBe(false)
 
-  validation = await label(createMock('Some Label'), config.settings)
+  validation = await label(createMockPR(), createMockContext('Some Label'), config.settings)
   expect(validation.mergeable).toBe(true)
 })
 
 test('mergeable is false if regex found or true if not when there are multiple labels', async () => {
   let config = (new Configuration()).settings
 
-  let validation = await label(createMock(['abc', 'experimental', 'xyz']), config)
+  let validation = await label(createMockPR(), createMockContext(['abc', 'experimental', 'xyz']), config)
   expect(validation.mergeable).toBe(false)
 
-  validation = await label(createMock(['Some Label', '123', '456']), config)
+  validation = await label(createMockPR(), createMockContext(['Some Label', '123', '456']), config)
   expect(validation.mergeable).toBe(true)
 })
 
 test('description is correct', async () => {
   let config = new Configuration()
-  let validation = await label(createMock('Work in Progress'), config.settings)
+  let validation = await label(createMockPR(),
+    createMockContext('Work in Progress'), config.settings)
 
   expect(validation.mergeable).toBe(false)
   expect(validation.description).toBe(`Label contains "${Configuration.DEFAULTS.label}"`)
 
-  validation = await label(createMock('Just Label'), config.settings)
+  validation = await label(createMockPR(), createMockContext('Just Label'), config.settings)
   expect(validation.description).toBe(null)
 })
 
-const createMock = (labels) => {
+const createMockContext = (labels) => {
   let labelArray = []
   if (Array.isArray(labels)) {
     labels.forEach((label) => {
@@ -53,9 +54,6 @@ const createMock = (labels) => {
 
   return {
     repo: jest.fn(),
-    payload: {
-      pull_request: { number: 1 }
-    },
     github: {
       issues: {
         getIssueLabels: () => {
@@ -64,4 +62,8 @@ const createMock = (labels) => {
       }
     }
   }
+}
+
+const createMockPR = () => {
+  return { number: 1 }
 }

--- a/__tests__/milestone.test.js
+++ b/__tests__/milestone.test.js
@@ -1,0 +1,44 @@
+const milestone = require('../lib/milestone')
+const Configuration = require('../lib/configuration')
+
+test('should be false when a different milestone is specified', async () => {
+  let validation = await milestone(createMockPayload('Version 2'), createMockConfig('Version 1').settings)
+  expect(validation.mergeable).toBe(false)
+})
+
+test('shoud be true regardless when milestone is null in settings', async () => {
+  let validation = await milestone(createMockPayload('Version 2'), (new Configuration()).settings)
+  expect(validation.mergeable).toBe(true)
+})
+
+test('shoud be false when milestone is set in settings but null in PR', async () => {
+  let validation = await milestone(createMockPayload(), createMockConfig('Version 1').settings)
+  expect(validation.mergeable).toBe(false)
+})
+
+test('description should be correct', async () => {
+  let settings = createMockConfig('Version 1').settings
+  let validation = await milestone(createMockPayload(), settings)
+  expect(validation.description).toBe(`Milestone must be ${settings.mergeable.milestone}"`)
+})
+
+const createMockConfig = (milestone) => {
+  return new Configuration(`
+    mergeable:
+      milestone: ${milestone}
+  `)
+}
+
+const createMockPayload = (milestone) => {
+  let data = {
+    payload: {
+      pull_request: {
+      }
+    }
+  }
+
+  if (milestone === undefined) data.payload.pull_request.milestone = null
+  else data.payload.pull_request.milestone = { title: milestone }
+
+  return data
+}

--- a/__tests__/milestone.test.js
+++ b/__tests__/milestone.test.js
@@ -2,25 +2,45 @@ const milestone = require('../lib/milestone')
 const Configuration = require('../lib/configuration')
 
 test('should be false when a different milestone is specified', async () => {
-  let validation = await milestone(createMockPayload('Version 2'), createMockConfig('Version 1').settings)
+  let validation = await milestone(createMockPR('Version 2'), null, createMockConfig('Version 1').settings)
   expect(validation.mergeable).toBe(false)
 })
 
 test('shoud be true regardless when milestone is null in settings', async () => {
-  let validation = await milestone(createMockPayload('Version 2'), (new Configuration()).settings)
+  let validation = await milestone(createMockPR('Version 2'), null, (new Configuration()).settings)
   expect(validation.mergeable).toBe(true)
 })
 
 test('shoud be false when milestone is set in settings but null in PR', async () => {
-  let validation = await milestone(createMockPayload(), createMockConfig('Version 1').settings)
+  let validation = await milestone(createMockPR(), null, createMockConfig('Version 1').settings)
   expect(validation.mergeable).toBe(false)
 })
 
 test('description should be correct', async () => {
   let settings = createMockConfig('Version 1').settings
-  let validation = await milestone(createMockPayload(), settings)
+  let validation = await milestone(createMockPR(), null, settings)
   expect(validation.description).toBe(`Milestone must be ${settings.mergeable.milestone}"`)
 })
+
+// TODO move this to a more relevant test when we refactor index.js
+// test('issue event that is a PR should validate appropriately', async () => {
+//   let settings = createMockConfig('Version 1').settings
+//   let validation = await milestone(createMockIssueEvent('version 1', true), settings)
+//   expect(validation.mergeable).toBe(true)
+//
+//   validation = await milestone(createMockIssueEvent('version 2', true), settings)
+//   expect(validation.mergeable).toBe(false)
+// })
+//
+
+// test('issue event that is NOT a PR should return mergeable as true', async () => {
+//   let settings = createMockConfig('Version 1').settings
+//
+//   let validation = await milestone(createMockIssueEvent('version 1', false), settings)
+//   expect(validation.mergeable).toBe(true)
+//   validation = await milestone(createMockIssueEvent('version 2', false), settings)
+//   expect(validation.mergeable).toBe(true)
+// })
 
 const createMockConfig = (milestone) => {
   return new Configuration(`
@@ -29,16 +49,21 @@ const createMockConfig = (milestone) => {
   `)
 }
 
-const createMockPayload = (milestone) => {
-  let data = {
-    payload: {
-      pull_request: {
-      }
-    }
-  }
+// TODO move this to a more relevant test when we refactor index.js
+// const createMockIssueEvent = (milestone, isPR) => {
+//   let data = {
+//     payload: {
+//       issue: { milestone: {title: milestone} }
+//     }
+//   }
+//
+//   if (isPR) data.payload.issue.pull_request = {url: 'https://api.github.com/repos/abc/def/pulls/1'}
+//
+//   return data
+// }
 
-  if (milestone === undefined) data.payload.pull_request.milestone = null
-  else data.payload.pull_request.milestone = { title: milestone }
-
-  return data
+const createMockPR = (milestone) => {
+  return { milestone: {
+    title: (milestone === undefined) ? null : milestone
+  }}
 }

--- a/__tests__/title.test.js
+++ b/__tests__/title.test.js
@@ -6,37 +6,31 @@ test('fail gracefully if invalid regex', async () => {
     mergeable:
       title: '@#$@#$@#$'
   `)
-  let titleValidation = await title(createMock('WIP Title'), config.settings)
+  let titleValidation = await title(createMockPR('WIP Title'), null, config.settings)
   expect(titleValidation.mergeable).toBe(true)
 })
 
 test('isMergeable is false if regex found or true if not', async () => {
   let config = new Configuration()
 
-  let titleValidation = await title(createMock('WIP Title'), config.settings)
+  let titleValidation = await title(createMockPR('WIP Title'), null, config.settings)
   expect(titleValidation.mergeable).toBe(false)
 
-  titleValidation = await title(createMock('Some Title'), config.settings)
+  titleValidation = await title(createMockPR('Some Title'), null, config.settings)
   expect(titleValidation.mergeable).toBe(true)
 })
 
 test('description is correct', async () => {
   let config = new Configuration()
-  let titleValidation = await title(createMock('WIP Title'), config.settings)
+  let titleValidation = await title(createMockPR('WIP Title'), null, config.settings)
 
   expect(titleValidation.mergeable).toBe(false)
   expect(titleValidation.description).toBe(`Title contains "${Configuration.DEFAULTS.title}"`)
 
-  titleValidation = await title(createMock('Just Title'), config.settings)
+  titleValidation = await title(createMockPR('Just Title'), null, config.settings)
   expect(titleValidation.description).toBe(null)
 })
 
-const createMock = (title) => {
-  return {
-    payload: {
-      pull_request: {
-        title: title
-      }
-    }
-  }
+const createMockPR = (title) => {
+  return { title: title }
 }

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+machine:
+  node:
+    version: 7.7.0

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const Configuration = require('./lib/configuration')
+const fetch = require('node-fetch')
 
 module.exports = (robot) => {
   robot.on(
@@ -10,20 +11,36 @@ module.exports = (robot) => {
       'pull_request.labeled',
       'pull_request.unlabeled'
     ],
-    handle
+    handlePullRequest
   )
 
-  async function handle (context) {
+  robot.on(['issues.milestoned', 'issues.demilestoned'], handleIssues)
+
+  // TODO abstract to lib and write tests.
+  async function handleIssues (context) {
+    if (context.payload.issue.pull_request) {
+      let res = await fetch(context.payload.issue.pull_request.url)
+      let pr = await res.json()
+      handle(context, pr)
+    }
+  }
+
+  async function handlePullRequest (context) {
+    handle(context, context.payload.pull_request)
+  }
+
+  var handle = async (context, pullRequest) => {
     var config = await Configuration.instanceWithContext(context)
     robot.log(config)
 
     let validators = []
     let includes = [ 'approvals', 'title', 'label', 'milestone' ]
+
     includes.forEach(validator => {
-      validators.push(require(`./lib/${validator}`)(context, config.settings))
+      validators.push(require(`./lib/${validator}`)(pullRequest, context, config.settings))
     })
 
-    Promise.all(validators).then((results) => {
+    Promise.all(validators).then(async (results) => {
       let failures = results.filter(validated => !validated.mergeable)
 
       let status, description
@@ -38,7 +55,7 @@ module.exports = (robot) => {
       }
 
       context.github.repos.createStatus(context.repo({
-        sha: context.payload.pull_request.head.sha,
+        sha: pullRequest.head.sha,
         state: status,
         target_url: 'https://github.com/apps/mergeable',
         description: description,

--- a/index.js
+++ b/index.js
@@ -1,7 +1,14 @@
 const Configuration = require('./lib/configuration')
 
 module.exports = (robot) => {
-  robot.log('')
+  robot.on(
+    [
+      'issues.milestoned'
+    ],
+    context => {
+      console.log(context.payload.issue.pull_request)
+    }
+  )
   robot.on(
     [ 'pull_request.opened',
       'pull_request.edited',
@@ -9,17 +16,19 @@ module.exports = (robot) => {
       'pull_request_review.edited',
       'pull_request_review.dismissed',
       'pull_request.labeled',
-      'pull_request.unlabeled'
+      'pull_request.unlabeled',
+      'pull_request.assigned',
+      'pull_request.unassigned'
     ],
     handle
   )
 
   async function handle (context) {
     var config = await Configuration.instanceWithContext(context)
-    console.log(config)
+    robot.log(config)
 
     let validators = []
-    let includes = [ 'approvals', 'title', 'label' ]
+    let includes = [ 'approvals', 'title', 'label', 'milestone' ]
     includes.forEach(validator => {
       validators.push(require(`./lib/${validator}`)(context, config.settings))
     })

--- a/index.js
+++ b/index.js
@@ -2,14 +2,6 @@ const Configuration = require('./lib/configuration')
 
 module.exports = (robot) => {
   robot.on(
-    [
-      'issues.milestoned'
-    ],
-    context => {
-      console.log(context.payload.issue.pull_request)
-    }
-  )
-  robot.on(
     [ 'pull_request.opened',
       'pull_request.edited',
       'pull_request_review.submitted',

--- a/index.js
+++ b/index.js
@@ -8,9 +8,7 @@ module.exports = (robot) => {
       'pull_request_review.edited',
       'pull_request_review.dismissed',
       'pull_request.labeled',
-      'pull_request.unlabeled',
-      'pull_request.assigned',
-      'pull_request.unassigned'
+      'pull_request.unlabeled'
     ],
     handle
   )

--- a/lib/approvals.js
+++ b/lib/approvals.js
@@ -6,10 +6,10 @@
  *  JSON object with the properties mergeable and the description if
  *  `mergeable` is false
  */
-module.exports = async (context, settings) => {
+module.exports = async (pr, context, settings) => {
   let min = settings.mergeable.approvals
   let reviews = await context.github.pullRequests.getReviews(
-    context.repo({ number: context.payload.pull_request.number })
+    context.repo({ number: pr.number })
   )
 
   let isMergeable = reviews.data

--- a/lib/label.js
+++ b/lib/label.js
@@ -6,8 +6,8 @@
  *  JSON object with the properties mergeable and the description if
  *  `mergeable` is false
  */
-module.exports = async (context, settings) => {
-  let prNumber = context.payload.pull_request.number
+module.exports = async (pr, context, settings) => {
+  let prNumber = pr.number
   let labels = await context.github.issues.getIssueLabels(
     context.repo({ number: prNumber })
   )

--- a/lib/milestone.js
+++ b/lib/milestone.js
@@ -1,0 +1,23 @@
+/**
+ * Determines if the the PR is mergeable based on the name of the milestone set
+ * in configuration. Mergeable only if the milestone specified in
+ * the configuration is associated to the PR.
+ *
+ * @return
+ *  JSON object with the properties mergeable and the description if
+ *  `mergeable` is false
+ */
+module.exports = async (context, settings) => {
+  let pr = context.payload.pull_request
+  let isMergeable = true
+
+  if (settings.mergeable.milestone) {
+    let regex = new RegExp(settings.mergeable.milestone, 'i')
+    isMergeable = pr.milestone != null && regex.test(pr.milestone.title)
+  }
+
+  return {
+    mergeable: isMergeable,
+    description: isMergeable ? null : `Milestone must be ${settings.mergeable.milestone}"`
+  }
+}

--- a/lib/milestone.js
+++ b/lib/milestone.js
@@ -7,12 +7,12 @@
  *  JSON object with the properties mergeable and the description if
  *  `mergeable` is false
  */
-module.exports = async (context, settings) => {
-  let pr = context.payload.pull_request
+module.exports = async (pr, context, settings) => {
   let isMergeable = true
 
   if (settings.mergeable.milestone) {
     let regex = new RegExp(settings.mergeable.milestone, 'i')
+
     isMergeable = pr.milestone != null && regex.test(pr.milestone.title)
   }
 

--- a/lib/title.js
+++ b/lib/title.js
@@ -6,8 +6,8 @@
  *  JSON object with the properties mergeable and the description if
  *  `mergeable` is false
  */
-module.exports = async (context, settings) => {
-  let title = context.payload.pull_request.title
+module.exports = async (pr, context, settings) => {
+  let title = pr.title
   let regex = new RegExp(settings.mergeable.title, 'i')
   let isMergeable = !regex.test(title)
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "js-yaml": "^3.11.0",
+    "node-fetch": "^2.1.2",
     "probot": "^5.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Goals
- Add a feature to prevent PR from being mergeable when the milestone configured does not match the milestone set on the PR.
- Updated README.