### PR TITLE
(feat) Exclude mergeable checks with configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,10 @@ mergeable:
   title: 'wip'
 
   # Only mergeable when milestone is as specified below.
-  milestone: 'version 1'  
+  milestone: version 1
+
+  # exclude any of the checks above. Comma separated list. For example, the following will exclude checks for approvals and label.
+  exclude: 'approvals, label'
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # The Mergeable Bot
 A GitHub App that prevents merging of pull requests based on [configurations](#configuration). Make your pull requests mergeable only when:
 
-- Certain terms are not in the **title** or **label**.
+- Certain terms are not in the **title** and/or **label**.
 
 - The **milestone** on the pull request matches with what is configured.
 
@@ -45,7 +45,7 @@ mergeable:
   title: 'wip'
 
   # Only mergeable when milestone is as specified below.
-  milestone: version 1
+  milestone: 'version 1'
 
   # exclude any of the checks above. Comma separated list. For example, the following will exclude checks for approvals and label.
   exclude: 'approvals, label'

--- a/__tests__/configuration.test.js
+++ b/__tests__/configuration.test.js
@@ -32,6 +32,7 @@ test('that defaults load correctly when mergeable is null', () => {
   expect(mergeable.approvals).toBe(Configuration.DEFAULTS.approvals)
   expect(mergeable.title).toBe(Configuration.DEFAULTS.title)
   expect(mergeable.label).toBe(Configuration.DEFAULTS.label)
+  expect(mergeable.exclude).toBe(undefined)
 })
 
 test('that defaults load correctly when mergeable has partial properties defined', () => {

--- a/__tests__/handler.test.js
+++ b/__tests__/handler.test.js
@@ -5,11 +5,7 @@ Configuration.DEFAULTS.approvals = 0
 
 test('handlePullRequest when it is mergeable', async () => {
   let context = mockContext('title')
-  Handler.handlePullRequest(context).then(() => {
-    expect(context.repo).lastCalledWith(
-      Helper.expectedStatus('success', 'Okay to merge.')
-    )
-  })
+  expectSuccessStatus(context)
 })
 
 test('handlePullRequest when it is NOT mergeable', async () => {
@@ -21,12 +17,51 @@ test('handlePullRequest when it is NOT mergeable', async () => {
   })
 })
 
+test('one exclude configuration will exclude the validation', async () => {
+  let context = Helper.mockContext({ title: 'wip' })
+  context.repo = mockRepo()
+
+  context.github.repos.getContent = () => {
+    return Promise.resolve({ data: { content: Buffer.from(`
+      mergeable:
+        approvals: 0
+        exclude: 'title'
+    `).toString('base64') }})
+  }
+  expectSuccessStatus(context)
+})
+
+test('more than one exclude configuration will exclude the validation', async () => {
+  let context = Helper.mockContext({ title: 'wip', label: ['proof of concept'] })
+  context.repo = mockRepo()
+
+  context.github.repos.getContent = () => {
+    return Promise.resolve({ data: { content: Buffer.from(`
+      mergeable:
+        exclude: 'approvals, title, label'
+    `).toString('base64') }})
+  }
+  expectSuccessStatus(context)
+})
+
 // TODO add tests for handleIssues
+
+const expectSuccessStatus = (context) => {
+  Handler.handlePullRequest(context).then(() => {
+    expect(context.repo).lastCalledWith(
+      Helper.expectedStatus('success', 'Okay to merge.')
+    )
+  })
+}
 
 const mockContext = (title) => {
   let context = Helper.mockContext({ title: title })
-  context.repo = jest.fn((arg) => {
+  context.repo = mockRepo()
+  return context
+}
+
+const mockRepo = () => {
+  return jest.fn((arg) => {
     if (!arg) return { owner: 'owner', repo: 'repo' }
   })
-  return context
 }

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -18,11 +18,15 @@ class Handler {
     var config = await Configuration.instanceWithContext(context)
 
     let validators = []
+    let excludes = (config.settings.mergeable.exclude)
+      ? config.settings.mergeable.exclude.split(',').map(val => val.trim()) : []
     let includes = [ 'approvals', 'title', 'label', 'milestone' ]
+      .filter(validator => excludes.indexOf(validator) === -1)
 
     includes.forEach(validator => {
       validators.push(require(`../lib/${validator}`)(pullRequest, context, config.settings))
     })
+
     console.info(config)
     Promise.all(validators).then(results => {
       let failures = results.filter(validated => !validated.mergeable)


### PR DESCRIPTION
## Goals
- Based on configuration, exclude mergeable checks by specifying comma separated list of checks.