### PR TITLE
Create pending status before validating.

### DIFF
--- a/__tests__/handler.test.js
+++ b/__tests__/handler.test.js
@@ -11,8 +11,7 @@ test('handlePullRequest when it is mergeable', async () => {
 test('handlePullRequest when it is NOT mergeable', async () => {
   let context = mockContext('wip')
 
-  setTimeout(() => {}, 10000)
-  await Handler.handlePullRequest(context).then(() => {
+  Handler.handlePullRequest(context).then(() => {
     expect(context.repo).lastCalledWith(
       Helper.expectedStatus('failure', 'Title contains "wip|dnm|exp|poc"')
     )
@@ -59,8 +58,7 @@ test('more than one exclude configuration will exclude the validation', async ()
 // TODO add tests for handleIssues
 
 const expectSuccessStatus = async (context) => {
-  setTimeout(() => {}, 10000)
-  await Handler.handlePullRequest(context)
+  Handler.handlePullRequest(context)
     .then(() => {
       expect(context.repo).lastCalledWith(
         Helper.expectedStatus('success', 'Okay to merge.')

--- a/__tests__/handler.test.js
+++ b/__tests__/handler.test.js
@@ -23,7 +23,7 @@ test('handle creates pending status', async () => {
 
   await Handler.handlePullRequest(context).then(() => {
     expect(context.repo).toBeCalledWith(
-      Helper.expectedStatus('pending', 'Checking to see if this is mergeable...')
+      Helper.expectedStatus('pending', 'Validating...')
     )
   })
 })

--- a/__tests__/handler.test.js
+++ b/__tests__/handler.test.js
@@ -11,7 +11,7 @@ test('handlePullRequest when it is mergeable', async () => {
 test('handlePullRequest when it is NOT mergeable', async () => {
   let context = mockContext('wip')
 
-  await Handler.handlePullRequest(context).then(() => {
+  Handler.handlePullRequest(context).then(() => {
     expect(context.repo).lastCalledWith(
       Helper.expectedStatus('failure', 'Title contains "wip|dnm|exp|poc"')
     )
@@ -58,9 +58,9 @@ test('more than one exclude configuration will exclude the validation', async ()
 // TODO add tests for handleIssues
 
 const expectSuccessStatus = async (context) => {
-  await Handler.handlePullRequest(context)
+  Handler.handlePullRequest(context)
     .then(() => {
-      expect(context.repo).toBeCalledWith(
+      expect(context.repo).lastCalledWith(
         Helper.expectedStatus('success', 'Okay to merge.')
       )
     })

--- a/__tests__/handler.test.js
+++ b/__tests__/handler.test.js
@@ -11,7 +11,8 @@ test('handlePullRequest when it is mergeable', async () => {
 test('handlePullRequest when it is NOT mergeable', async () => {
   let context = mockContext('wip')
 
-  Handler.handlePullRequest(context).then(() => {
+  setTimeout(() => {}, 10000)
+  await Handler.handlePullRequest(context).then(() => {
     expect(context.repo).lastCalledWith(
       Helper.expectedStatus('failure', 'Title contains "wip|dnm|exp|poc"')
     )
@@ -58,7 +59,8 @@ test('more than one exclude configuration will exclude the validation', async ()
 // TODO add tests for handleIssues
 
 const expectSuccessStatus = async (context) => {
-  Handler.handlePullRequest(context)
+  setTimeout(() => {}, 10000)
+  await Handler.handlePullRequest(context)
     .then(() => {
       expect(context.repo).lastCalledWith(
         Helper.expectedStatus('success', 'Okay to merge.')

--- a/__tests__/handler.test.js
+++ b/__tests__/handler.test.js
@@ -60,7 +60,7 @@ test('more than one exclude configuration will exclude the validation', async ()
 const expectSuccessStatus = async (context) => {
   await Handler.handlePullRequest(context)
     .then(() => {
-      expect(context.repo).lastCalledWith(
+      expect(context.repo).toBeCalledWith(
         Helper.expectedStatus('success', 'Okay to merge.')
       )
     })

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -15,11 +15,16 @@ class Handler {
   }
 
   static async handle (context, pullRequest) {
+    // let the user know that we are validating if PR is mergeable
+    context.github.repos.createStatus(
+      statusInfo(context, pullRequest, 'pending', 'Validating...')
+    )
+
     var config = await Configuration.instanceWithContext(context)
 
     let validators = []
-    let excludes = (config.settings.mergeable.exclude)
-      ? config.settings.mergeable.exclude.split(',').map(val => val.trim()) : []
+    let excludes = (config.settings.mergeable.exclude)?
+      config.settings.mergeable.exclude.split(',').map(val=>val.trim()) : []
     let includes = [ 'approvals', 'title', 'label', 'milestone' ]
       .filter(validator => excludes.indexOf(validator) === -1)
 
@@ -42,19 +47,25 @@ class Handler {
           .join(',\n')
       }
 
-      context.github.repos.createStatus(context.repo({
-        sha: pullRequest.head.sha,
-        state: status,
-        target_url: 'https://github.com/apps/mergeable',
-        description: description,
-        context: 'Mergeable'
-      }))
+      context.github.repos.createStatus(
+        statusInfo(context, pullRequest, status, description)
+      )
       console.info({state: status, description: description})
     }).catch(error => {
       // (jusx) This should never ever happen. Log it.
       console.error(error)
     })
   }
+}
+
+const statusInfo = (context, pullRequest, status, description) => {
+  return context.repo({
+    sha: pullRequest.head.sha,
+    state: status,
+    target_url: 'https://github.com/apps/mergeable',
+    description: description,
+    context: 'Mergeable'
+  })
 }
 
 module.exports = Handler

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -23,8 +23,8 @@ class Handler {
     var config = await Configuration.instanceWithContext(context)
 
     let validators = []
-    let excludes = (config.settings.mergeable.exclude)?
-      config.settings.mergeable.exclude.split(',').map(val=>val.trim()) : []
+    let excludes = (config.settings.mergeable.exclude)
+      ? config.settings.mergeable.exclude.split(',').map(val => val.trim()) : []
     let includes = [ 'approvals', 'title', 'label', 'milestone' ]
       .filter(validator => excludes.indexOf(validator) === -1)
 

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -6,12 +6,12 @@ class Handler {
     if (context.payload.issue.pull_request) {
       let res = await fetch(context.payload.issue.pull_request.url)
       let pr = await res.json()
-      await this.handle(context, pr)
+      return this.handle(context, pr)
     }
   }
 
   static async handlePullRequest (context) {
-    await this.handle(context, context.payload.pull_request)
+    return this.handle(context, context.payload.pull_request)
   }
 
   static async handle (context, pullRequest) {
@@ -33,7 +33,7 @@ class Handler {
     })
 
     console.info(config)
-    Promise.all(validators).then(results => {
+    return Promise.all(validators).then(results => {
       let failures = results.filter(validated => !validated.mergeable)
 
       let status, description


### PR DESCRIPTION
## Goals
- Create `pending` status on PR before mergeable validations.
- Add tests. Improved handler test to ensure test failures bubble up by waiting for the promise.

closes #17 

