### PR TITLE
enforce consistency in title + tests

### DIFF
--- a/__tests__/title.test.js
+++ b/__tests__/title.test.js
@@ -2,6 +2,17 @@ const Helper = require('../__fixtures__/helper')
 const title = require('../lib/title')
 const Configuration = require('../lib/configuration')
 
+test('fail gracefully if invalid setting is provided', async () => {
+  // try to pass an array instead
+  let config = new Configuration(`
+    mergeable:
+      title: ['item 1', 'item 2' ]
+  `)
+
+  let titleValidation = await title(createMockPR('Valid Title'), null, config.settings)
+  expect(titleValidation.mergeable).toBe(true)
+})
+
 test('fail gracefully if invalid regex', async () => {
   let config = new Configuration(`
     mergeable:
@@ -9,6 +20,42 @@ test('fail gracefully if invalid regex', async () => {
   `)
   let titleValidation = await title(createMockPR('WIP Title'), null, config.settings)
   expect(titleValidation.mergeable).toBe(true)
+})
+
+test('checks that it fail when exclude regex is in title', async () => {
+  // try to pass an array instead
+  let config = new Configuration(`
+    mergeable:
+      title: 
+        must-include: '^\\(feat\\)|^\\(doc\\)|^\\(fix\\)' 
+        must-exclude: 'wip'
+  `)
+
+  let titleValidation = await title(createMockPR('WIP Title'), null, config.settings)
+
+  expect(titleValidation.mergeable).toBe(false)
+
+  titleValidation = await title(createMockPR('(feat) WIP Title'), null, config.settings)
+
+  expect(titleValidation.mergeable).toBe(false)
+})
+
+test('checks that it fail when include regex is in title', async () => {
+  let includeList = `^\\(feat\\)|^\\(doc\\)|^\\(fix\\)`
+  let config = new Configuration(`
+    mergeable:
+      title: 
+        must-include: ${includeList}
+        must-exclude: 'wip'
+  `)
+
+  let titleValidation = await title(createMockPR('include Title'), null, config.settings)
+  expect(titleValidation.mergeable).toBe(false)
+  expect(titleValidation.description[0]).toBe(`Title does not contain "${includeList}"`)
+
+  titleValidation = await title(createMockPR('(feat) WIP Title'), null, config.settings)
+
+  expect(titleValidation.mergeable).toBe(false)
 })
 
 test('isMergeable is false if regex found or true if not', async () => {

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -1,60 +1,65 @@
-module.exports = {
-  /**
-   *
-   * @param input the string run regex against
-   * @param filters string | object , if string we check if that regex is excluded from input
-   * @returns object { mergeable: bool, description: string | [string]}
-   */
-  processFilters: function (input, filters) {
-    // for backward compatibility, check if the filters is a string
+/**
+ *
+ * @param input the string run regex against
+ * @param filters string | object , if string we check if that regex is excluded from input
+ * @returns object { mergeable: bool, description: string | [string]}
+ */
+const processFilters = (input, filters) => {
+  // for backward compatibility, check if the filters is a string
+  if (typeof filters === 'string') {
+    return mustExclude(input, filters)
+  }
 
-    if (typeof filters === 'string') {
-      return this.mustExclude(input, filters)
-    }
-
-    let output = []
-    for (let key in filters) {
-      switch (key) {
-        case 'must-include':
-          output.push(this.mustInclude(input, filters[key]))
-          break
-        case 'must-exclude':
-          output.push(this.mustExclude(input, filters[key]))
-          break
-      }
-    }
-
-    return this.mergeResults(output)
-  },
-  mergeResults: function (result) {
-    let mergeable = true
-    let errorMessages = []
-
-    result.forEach(res => {
-      if (!res.mergeable) {
-        mergeable = false
-      }
-
-      if (res.description) {
-        errorMessages.push(res.description)
-      }
-    })
-
-    return {mergeable, description: errorMessages}
-  },
-  mustInclude: function (input, match) {
-    const regex = new RegExp(match, 'i')
-    const isMergeable = regex.test(input)
-    return { mergeable: isMergeable,
-      description: isMergeable ? null : `Title does not contain "${match}"`
-    }
-  },
-  mustExclude: function (input, match) {
-    const regex = new RegExp(match, 'i')
-    const isMergeable = !regex.test(input)
-
-    return { mergeable: isMergeable,
-      description: isMergeable ? null : `Title contains "${match}"`
+  let output = []
+  for (let key in filters) {
+    switch (key) {
+      case 'must-include':
+        output.push(mustInclude(input, filters[key]))
+        break
+      case 'must-exclude':
+        output.push(mustExclude(input, filters[key]))
+        break
     }
   }
+
+  return mergeResults(output)
 }
+
+const mergeResults = (result) => {
+  let mergeable = true
+  let errorMessages = []
+
+  result.forEach(res => {
+    if (!res.mergeable) {
+      mergeable = false
+    }
+
+    if (res.description) {
+      errorMessages.push(res.description)
+    }
+  })
+
+  return {mergeable, description: errorMessages}
+}
+
+const mustInclude = (input, match) => {
+  const regex = new RegExp(match, 'i')
+  const isMergeable = regex.test(input)
+
+  return {
+    mergeable: isMergeable,
+    description: isMergeable ? null : `Title does not contain "${match}"`
+  }
+}
+
+const mustExclude = (input, match) => {
+  const regex = new RegExp(match, 'i')
+  const isMergeable = !regex.test(input)
+
+  return {
+    mergeable: isMergeable,
+    description: isMergeable ? null : `Title contains "${match}"`
+  }
+}
+
+module.exports = processFilters

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -1,0 +1,60 @@
+module.exports = {
+  /**
+   *
+   * @param input the string run regex against
+   * @param filters string | object , if string we check if that regex is excluded from input
+   * @returns object { mergeable: bool, description: string | [string]}
+   */
+  processFilters: function (input, filters) {
+    // for backward compatibility, check if the filters is a string
+
+    if (typeof filters === 'string') {
+      return this.mustExclude(input, filters)
+    }
+
+    let output = []
+    for (let key in filters) {
+      switch (key) {
+        case 'must-include':
+          output.push(this.mustInclude(input, filters[key]))
+          break
+        case 'must-exclude':
+          output.push(this.mustExclude(input, filters[key]))
+          break
+      }
+    }
+
+    return this.mergeResults(output)
+  },
+  mergeResults: function (result) {
+    let mergeable = true
+    let errorMessages = []
+
+    result.forEach(res => {
+      if (!res.mergeable) {
+        mergeable = false
+      }
+
+      if (res.description) {
+        errorMessages.push(res.description)
+      }
+    })
+
+    return {mergeable, description: errorMessages}
+  },
+  mustInclude: function (input, match) {
+    const regex = new RegExp(match, 'i')
+    const isMergeable = regex.test(input)
+    return { mergeable: isMergeable,
+      description: isMergeable ? null : `Title does not contain "${match}"`
+    }
+  },
+  mustExclude: function (input, match) {
+    const regex = new RegExp(match, 'i')
+    const isMergeable = !regex.test(input)
+
+    return { mergeable: isMergeable,
+      description: isMergeable ? null : `Title contains "${match}"`
+    }
+  }
+}

--- a/lib/title.js
+++ b/lib/title.js
@@ -10,6 +10,5 @@ const processor = require('../lib/processor')
  */
 module.exports = async (pr, context, settings) => {
   let title = pr.title
-
-  return processor.processFilters(title, settings.mergeable.title)
+  return processor(title, settings.mergeable.title)
 }

--- a/lib/title.js
+++ b/lib/title.js
@@ -1,3 +1,5 @@
+const processor = require('../lib/processor')
+
 /**
  * Determines if the the PR is mergeable based on regex expression set for
  * title.
@@ -8,11 +10,6 @@
  */
 module.exports = async (pr, context, settings) => {
   let title = pr.title
-  let regex = new RegExp(settings.mergeable.title, 'i')
-  let isMergeable = !regex.test(title)
 
-  return {
-    mergeable: isMergeable,
-    description: isMergeable ? null : `Title contains "${settings.mergeable.title}"`
-  }
+  return processor.processFilters(title, settings.mergeable.title)
 }


### PR DESCRIPTION
A second attempt at enforcing consistency in title by putting using a library to allow for re-usability and easily add more filters. 

@jusx I changed the `include` and `exclude` to `must-include` and `must-exclude` respectively to avoid confusion. 
Since we can also add many different filter, i think it make sense to show all the things that failed, I turned the `description` field into an array which holds all the errors. Backward compatibility is maintained so `description` can also be a string as well.

closes #15 