### PR TITLE
allow advance settings in title

### DIFF
--- a/__tests__/title.test.js
+++ b/__tests__/title.test.js
@@ -27,8 +27,8 @@ test('checks that it fail when exclude regex is in title', async () => {
   let config = new Configuration(`
     mergeable:
       title: 
-        must-include: '^\\(feat\\)|^\\(doc\\)|^\\(fix\\)' 
-        must-exclude: 'wip'
+        must_include: '^\\(feat\\)|^\\(doc\\)|^\\(fix\\)' 
+        must_exclude: 'wip'
   `)
 
   let titleValidation = await title(createMockPR('WIP Title'), null, config.settings)
@@ -40,13 +40,34 @@ test('checks that it fail when exclude regex is in title', async () => {
   expect(titleValidation.mergeable).toBe(false)
 })
 
+test('checks that advance setting of must_include works', async () => {
+  let includeList = `^\\(feat\\)|^\\(doc\\)|^\\(fix\\)`
+  let testMessage = 'this is a test message'
+  let config = new Configuration(`
+    mergeable:
+      title: 
+        must_include: 
+          regex: ${includeList}
+          message: ${testMessage}
+        must_exclude: 'wip'
+  `)
+
+  let titleValidation = await title(createMockPR('include Title'), null, config.settings)
+  expect(titleValidation.mergeable).toBe(false)
+  expect(titleValidation.description[0]).toBe(testMessage)
+
+  titleValidation = await title(createMockPR('(feat) WIP Title'), null, config.settings)
+
+  expect(titleValidation.mergeable).toBe(false)
+})
+
 test('checks that it fail when include regex is in title', async () => {
   let includeList = `^\\(feat\\)|^\\(doc\\)|^\\(fix\\)`
   let config = new Configuration(`
     mergeable:
       title: 
-        must-include: ${includeList}
-        must-exclude: 'wip'
+        must_include: ${includeList}
+        must_exclude: 'wip'
   `)
 
   let titleValidation = await title(createMockPR('include Title'), null, config.settings)

--- a/__tests__/title.test.js
+++ b/__tests__/title.test.js
@@ -61,6 +61,42 @@ test('checks that advance setting of must_include works', async () => {
   expect(titleValidation.mergeable).toBe(false)
 })
 
+test('checks that it fail when begins_with is not in title', async () => {
+  let match = '(test)'
+  let config = new Configuration(`
+    mergeable:
+      title: 
+        begins_with: 
+          match: ${match} 
+  `)
+
+  let titleValidation = await title(createMockPR('include Title'), null, config.settings)
+  expect(titleValidation.mergeable).toBe(false)
+  expect(titleValidation.description[0]).toBe(`Must begins with "${match}"`)
+
+  titleValidation = await title(createMockPR('(test) WIP Title'), null, config.settings)
+
+  expect(titleValidation.mergeable).toBe(true)
+})
+
+test('checks that it fail when ends_with is not in title', async () => {
+  let match = '(test)'
+  let config = new Configuration(`
+    mergeable:
+      title: 
+        ends_with: 
+          match: ${match} 
+  `)
+
+  let titleValidation = await title(createMockPR('include Title'), null, config.settings)
+  expect(titleValidation.mergeable).toBe(false)
+  expect(titleValidation.description[0]).toBe(`Must ends with "${match}"`)
+
+  titleValidation = await title(createMockPR('WIP Title (test)'), null, config.settings)
+
+  expect(titleValidation.mergeable).toBe(true)
+})
+
 test('checks that it fail when include regex is in title', async () => {
   let includeList = `^\\(feat\\)|^\\(doc\\)|^\\(fix\\)`
   let config = new Configuration(`

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -136,8 +136,7 @@ const max = (input, filters) => {
 const beginsWith = (input, filters) => {
   let {match, description} = extractFilterParameter(filters)
   if (!description) description = `Must begins with "${match}"`
-  const regex = new RegExp(`^${match}`, 'i')
-  const isMergeable = regex.test(input)
+  const isMergeable = input.indexOf(match) === 0
 
   return {
     mergeable: isMergeable,
@@ -148,8 +147,7 @@ const beginsWith = (input, filters) => {
 const endsWith = (input, filters) => {
   let {match, description} = extractFilterParameter(filters)
   if (!description) description = `Must ends with "${match}"`
-  const regex = new RegExp(`${match}&`, 'i')
-  const isMergeable = regex.test(input)
+  const isMergeable = input.indexOf(match) === (input.length - match.length)
 
   return {
     mergeable: isMergeable,

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -134,9 +134,10 @@ const max = (input, filters) => {
 }
 
 const beginsWith = (input, filters) => {
-  let {max, description} = extractFilterParameter(filters)
-  if (!description) description = `Assignee count is more than "${max}"`
-  const isMergeable = input.length > max
+  let {match, description} = extractFilterParameter(filters)
+  if (!description) description = `Must begins with "${match}"`
+  const regex = new RegExp(`^${match}`, 'i')
+  const isMergeable = regex.test(input)
 
   return {
     mergeable: isMergeable,
@@ -145,9 +146,10 @@ const beginsWith = (input, filters) => {
 }
 
 const endsWith = (input, filters) => {
-  let {max, description} = extractFilterParameter(filters)
-  if (!description) description = `Assignee count is more than "${max}"`
-  const isMergeable = input.length > max
+  let {match, description} = extractFilterParameter(filters)
+  if (!description) description = `Must ends with "${match}"`
+  const regex = new RegExp(`${match}&`, 'i')
+  const isMergeable = regex.test(input)
 
   return {
     mergeable: isMergeable,

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -13,11 +13,28 @@ const processFilters = (input, filters) => {
   let output = []
   for (let key in filters) {
     switch (key) {
-      case 'must-include':
+      case 'must_include':
         output.push(mustInclude(input, filters[key]))
         break
-      case 'must-exclude':
+      case 'must_exclude':
         output.push(mustExclude(input, filters[key]))
+        break
+      case 'min':
+        output.push(min(input, filters[key]))
+        break
+      case 'max':
+        output.push(max(input, filters[key]))
+        break
+      case 'begins_with':
+        output.push(beginsWith(input, filters[key]))
+        break
+      case 'ends_with':
+        output.push(endsWith(input, filters[key]))
+        break
+      case 'no-empty':
+        output.push(noEmpty(input, filters[key]))
+        break
+      default:
         break
     }
   }
@@ -42,23 +59,110 @@ const mergeResults = (result) => {
   return {mergeable, description: errorMessages}
 }
 
-const mustInclude = (input, match) => {
-  const regex = new RegExp(match, 'i')
-  const isMergeable = regex.test(input)
+const extractFilterParameter = (params) => {
+  if (typeof params === 'string') return { regex: params }
+
+  const output = {}
+  for (let key in params) {
+    switch (key) {
+      case 'regex':
+        output.regex = params.regex
+        break
+      case 'match':
+        output.match = params.match
+        break
+      case 'message':
+        output.description = params.message
+        break
+      case 'min':
+        output.min = params.min
+        break
+      case 'max':
+        output.max = params.max
+        break
+      case 'enabled':
+        output.enabled = params.enabled
+        break
+      default:
+        break
+    }
+  }
+  return output
+}
+
+const mustInclude = (input, filters) => {
+  let {regex, description} = extractFilterParameter(filters)
+  if (!description) description = `Title does not contain "${regex}"`
+  const isMergeable = new RegExp(regex, 'i').test(input)
 
   return {
     mergeable: isMergeable,
-    description: isMergeable ? null : `Title does not contain "${match}"`
+    description: isMergeable ? null : description
   }
 }
 
-const mustExclude = (input, match) => {
-  const regex = new RegExp(match, 'i')
-  const isMergeable = !regex.test(input)
+const mustExclude = (input, filters) => {
+  let {regex, description} = extractFilterParameter(filters)
+  if (!description) description = `Title contains "${regex}"`
+  const isMergeable = !(new RegExp(regex, 'i').test(input))
 
   return {
     mergeable: isMergeable,
-    description: isMergeable ? null : `Title contains "${match}"`
+    description: isMergeable ? null : description
+  }
+}
+const min = (input, filters) => {
+  let {min, description} = extractFilterParameter(filters)
+  if (!description) description = `Assignee count is less than "${min}"`
+  const isMergeable = input.length < min
+
+  return {
+    mergeable: isMergeable,
+    description: isMergeable ? null : description
+  }
+}
+
+const max = (input, filters) => {
+  let {max, description} = extractFilterParameter(filters)
+  if (!description) description = `Assignee count is more than "${max}"`
+  const isMergeable = input.length > max
+
+  return {
+    mergeable: isMergeable,
+    description: isMergeable ? null : description
+  }
+}
+
+const beginsWith = (input, filters) => {
+  let {max, description} = extractFilterParameter(filters)
+  if (!description) description = `Assignee count is more than "${max}"`
+  const isMergeable = input.length > max
+
+  return {
+    mergeable: isMergeable,
+    description: isMergeable ? null : description
+  }
+}
+
+const endsWith = (input, filters) => {
+  let {max, description} = extractFilterParameter(filters)
+  if (!description) description = `Assignee count is more than "${max}"`
+  const isMergeable = input.length > max
+
+  return {
+    mergeable: isMergeable,
+    description: isMergeable ? null : description
+  }
+}
+
+const noEmpty = (input, filters) => {
+  let {enabled, description} = extractFilterParameter(filters)
+  if (!description) description = `The description can't be empty`
+  const isMergeable = !(enabled && input.trim().length === 0)
+
+  return {
+    mergeable: isMergeable,
+    description: isMergeable ? null : description
   }
 }
 


### PR DESCRIPTION
fix `must-include` to `must_include` instead
added other filter cases: `min`, `max`, `begins_with`, `ends_with`, `no_empty`
allow for sub filter: `regex`, `min`, `max`, `match`, `message` and `enabled`