### PR TITLE
advance setting for approval implemented

### DIFF
--- a/__tests__/approvals.test.js
+++ b/__tests__/approvals.test.js
@@ -85,6 +85,40 @@ test('mergeable is false if required user has not approved', async () => {
   expect(validation.description).toBe(null)
 })
 
+test('mergeable advanceSetting min works', async () => {
+  let configuration = `
+  mergeable:
+    approvals:
+      min: 
+        count: 2
+        message: 'This is a test message'
+  `
+
+  let validation = await approvals({ number: 1 }, createMockContext(1), config({config: configuration}))
+  expect(validation.mergeable).toBe(false)
+  expect(validation.description[0]).toBe('This is a test message')
+
+  validation = await approvals({ number: 1 }, createMockContext(3), config({config: configuration}))
+  expect(validation.mergeable).toBe(true)
+})
+
+test('mergeable advanceSetting max works', async () => {
+  let configuration = `
+  mergeable:
+    approvals:
+      max: 
+        count: 2
+        message: 'This is a test message'
+  `
+
+  let validation = await approvals({ number: 1 }, createMockContext(3), config({config: configuration}))
+  expect(validation.mergeable).toBe(false)
+  expect(validation.description[0]).toBe('This is a test message')
+
+  validation = await approvals({ number: 1 }, createMockContext(1), config({config: configuration}))
+  expect(validation.mergeable).toBe(true)
+})
+
 const createMockContext = (minimum, data) => {
   if (!data) {
     data = []

--- a/__tests__/approvals.test.js
+++ b/__tests__/approvals.test.js
@@ -144,11 +144,11 @@ test('mergeable advanceSetting min works', async () => {
         message: 'This is a test message'
   `
 
-  let validation = await approvals({ number: 1 }, createMockContext(1), config({config: configuration}))
+  let validation = await approvals(defaultPR, createMockContext(1), config({config: configuration}))
   expect(validation.mergeable).toBe(false)
   expect(validation.description[0]).toBe('This is a test message')
 
-  validation = await approvals({ number: 1 }, createMockContext(3), config({config: configuration}))
+  validation = await approvals(defaultPR, createMockContext(3), config({config: configuration}))
   expect(validation.mergeable).toBe(true)
 })
 
@@ -161,11 +161,11 @@ test('mergeable advanceSetting max works', async () => {
         message: 'This is a test message'
   `
 
-  let validation = await approvals({ number: 1 }, createMockContext(3), config({config: configuration}))
+  let validation = await approvals(defaultPR, createMockContext(3), config({config: configuration}))
   expect(validation.mergeable).toBe(false)
   expect(validation.description[0]).toBe('This is a test message')
 
-  validation = await approvals({ number: 1 }, createMockContext(1), config({config: configuration}))
+  validation = await approvals(defaultPR, createMockContext(1), config({config: configuration}))
   expect(validation.mergeable).toBe(true)
 })
 

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -77,17 +77,14 @@ const extractFilterParameter = (params) => {
       case 'message':
         output.description = params.message
         break
-      case 'min':
-        output.min = params.min
-        break
-      case 'max':
-        output.max = params.max
-        break
       case 'enabled':
         output.enabled = params.enabled
         break
       case 'reviewers':
         output.reviewers = params.reviewers
+        break
+      case 'count':
+        output.count = params.count
         break
       default:
         break
@@ -139,7 +136,7 @@ const min = (validatorContext, input, filters) => {
     min = filters
   } else {
     let res = extractFilterParameter(filters)
-    min = res.min
+    min = res.count
     description = res.description
   }
 
@@ -153,9 +150,16 @@ const min = (validatorContext, input, filters) => {
 }
 
 const max = (validatorContext, input, filters) => {
-  let {max, description} = extractFilterParameter(filters)
+  let max, description
+  if (typeof filters === 'number') {
+    max = filters
+  } else {
+    let res = extractFilterParameter(filters)
+    max = res.count
+    description = res.description
+  }
   if (!description) description = `${validatorContext} count is more than "${max}"`
-  const isMergeable = input.length > max
+  const isMergeable = !(input.length > max)
 
   return {
     mergeable: isMergeable,


### PR DESCRIPTION
closes #31 

instead of 
```
min: 5
  message: '...'
```
this was implemented

```
min: 
  count: 5
  message: '...'
```