### PR TITLE
fix bug where adding milestone throws error

### DIFF
--- a/lib/handler.js
+++ b/lib/handler.js
@@ -7,6 +7,7 @@ class Handler {
     if (context.payload.issue.pull_request) {
       let res = await fetch(context.payload.issue.pull_request.url)
       let pr = await res.json()
+      context.payload.pull_request = pr
       return this.handle(context, pr)
     }
   }


### PR DESCRIPTION
this was caused because checks is expecting context.payload.pull_request and didn't find it