### PR TITLE
Added the missing part about local deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,14 +156,20 @@ However you may want to have more advanced rulesets:
 
 ### Deploy your own
 
-If you would like to run your own instance of this plugin, you can do so by forking this repo and deploying it to your own servers.
+If you would like to run your own instance of this plugin, you can do so by forking this repo and deploying it to your own servers or run it locally.
 
-[Create a GitHub App](https://github.com/settings/apps/new) and configure the permissions & events with the following settings:
+[Create a GitHub App](https://github.com/settings/apps/new) and configure the permissions & events with the following: 
 
-- Repository metadata - **Read Only**
-- Commit Statuses - **Read & Write**
-- Pull requests - **Read Only**
+settings:
+- GitHub app name - **Your app name**
+- Webhook URL - **Your webhook url for listening to events** (local deployments you can use [smee.io](smee.io))
+- Webhook secret - **Your generated webhook seceret** 
+
+permissions:
 - Issues - **Read Only**
+- Repository metadata - **Read Only**
+- Pull requests - **Read Only**
+- Commit Statuses - **Read & Write**
 - Single File - **Read-only**
   - Path: `.github/mergeable.yml`
 
@@ -172,6 +178,17 @@ And subscription to the following events:
 - [x] Pull request review comment
 - [x] Pull request review
 - [x] Issues
+
+Depending on the type of deployment with probot please look at [ProBot Deployment Guide](https://probot.github.io/docs/deployment).
+
+Running Locally: 
+1. Clone the forked repository on to your machine
+2. Globally install smee-client from with npm ```npm install -g smee-client```
+3. Export all the variables required based on the ProBot deployment guide above 
+4. Run smee in your terminal by using the ```smee``` command
+5. Run npm start in your local repository 
+6. Add a repository for your Github app by going to [application settings](https://github.com/settings/installations)
+7. Do a test pull request to check if everything is working
 
 ## Contributions
 On [Github](https://github.com/jusx/mergeable): [Contribute](https://github.com/jusx/mergeable/blob/master/CONTRIBUTING.md) by creating a pull request or create a [new issue](https://github.com/jusx/mergeable/issues) to request for features.


### PR DESCRIPTION
I have changed the order of permissions to the order they appear on GitHub so the users don't have to jump around. I have also added a settings section for the required parameters when setting up a new app. Finally, I have added the steps to run a local deployment.

Let me know what you guys think.