### PR TITLE
(feat) Validate dependent files

### DIFF
--- a/__fixtures__/helper.js
+++ b/__fixtures__/helper.js
@@ -62,6 +62,9 @@ module.exports = {
           }
         },
         pullRequests: {
+          getFiles: () => {
+            return { data: options.files && options.files.map(file => ({filename: file, status: 'modified'})) }
+          },
           getReviews: () => {
             return { data: (options.reviews) ? options.reviews : [] }
           }

--- a/__tests__/dependent.test.js
+++ b/__tests__/dependent.test.js
@@ -1,0 +1,50 @@
+const Helper = require('../__fixtures__/helper')
+const dependent = require('../lib/dependent')
+const Configuration = require('../lib/configuration')
+
+const mockPR = {number: 1}
+
+test('that mergeable is true if none of the dependent file is modified', async () => {
+  let validation = await dependent(mockPR, createMockContext([]), config(['package.json', 'yarn.lock']))
+  expect(validation.mergeable).toBe(true)
+})
+
+test('that mergeable is true if all of the dependent file is modified', async () => {
+  let validation = await dependent(mockPR, createMockContext(['package.json', 'yarn.lock']), config(['package.json', 'yarn.lock']))
+  expect(validation.mergeable).toBe(true)
+})
+
+test('that mergeable is false when only some of the dependent files are modified', async () => {
+  let validation = await dependent(mockPR, createMockContext(['package.json']), config(['package.json', 'yarn.lock']))
+  expect(validation.mergeable).toBe(false)
+})
+
+test('test description is correct', async () => {
+  let defaultMessage = `One of the following file is modified, all the other files in the list must be modified as well 
+  -package.json,
+  -yarn.lock`
+  let validation = await dependent(mockPR, createMockContext(['package.json']), config(['package.json', 'yarn.lock']))
+  expect(validation.mergeable).toBe(false)
+  expect(validation.description).toBe(defaultMessage)
+})
+
+test('test that custom message is correct', async () => {
+  let customMessage = 'Test Message'
+  let validation = await dependent(mockPR, createMockContext(['package.json']), config(['package.json', 'yarn.lock'], customMessage))
+  expect(validation.mergeable).toBe(false)
+  expect(validation.description).toBe(customMessage)
+})
+
+const createMockContext = (files) => {
+  return Helper.mockContext({files: files})
+}
+
+const config = (files, message) => {
+  return (new Configuration(`
+  mergeable:
+    pull_request:
+      dependent:
+        files: [${files}]
+        ${message ? `message: ${message}` : ``}
+`)).settings.mergeable.pull_request
+}

--- a/__tests__/dependent.test.js
+++ b/__tests__/dependent.test.js
@@ -20,9 +20,9 @@ test('that mergeable is false when only some of the dependent files are modified
 })
 
 test('test description is correct', async () => {
-  let defaultMessage = `One of the following file is modified, all the other files in the list must be modified as well 
-  -package.json,
-  -yarn.lock`
+  let defaultMessage = `One of the following file is modified, all the other files in the list must be modified as well:
+  - package.json,
+  - yarn.lock`
   let validation = await dependent(mockPR, createMockContext(['package.json']), config(['package.json', 'yarn.lock']))
   expect(validation.mergeable).toBe(false)
   expect(validation.description).toBe(defaultMessage)

--- a/docs/README.md
+++ b/docs/README.md
@@ -229,6 +229,10 @@ Here's an example configuration file for advanced settings and all of it's possi
         min: 1
         max: 1
         message: 'Custom message...'
+      
+      dependent:
+        files: [] // list of files that all must be modified if one is modified
+        message: 'Custom message...' 
 
     #####
     #  Advanced settings for issues. When any of the rules  below is not valid Mergeable will create a comment on that issue to let the author know.    

--- a/docs/README.md
+++ b/docs/README.md
@@ -231,7 +231,7 @@ Here's an example configuration file for advanced settings and all of it's possi
         message: 'Custom message...'
       
       dependent:
-        files: [] // list of files that all must be modified if one is modified
+        files: ['package.json', 'yarn.lock'] # list of files that all must be modified if one is modified
         message: 'Custom message...' 
 
     #####

--- a/lib/dependent.js
+++ b/lib/dependent.js
@@ -18,7 +18,7 @@ module.exports = async (pr, context, settings) => {
 
   let dependentFiles = settings.dependent.files
   let message = settings.dependent.message ||
-    'One of the following file is modified, all the other files in the list must be modified as well ' + dependentFiles.map(name => '\n  -' + name)
+    'One of the following file is modified, all the other files in the list must be modified as well:' + dependentFiles.map(name => '\n  - ' + name)
 
   // fetch the file list
   let result = await context.github.pullRequests.getFiles(context.repo({number: pr.number}))

--- a/lib/dependent.js
+++ b/lib/dependent.js
@@ -1,0 +1,35 @@
+const _ = require('lodash')
+
+/**
+ * process the PR based on dependent settings
+ *
+ * @return
+ *  JSON object with the properties mergeable and the description if
+ *  `mergeable` is false
+ */
+module.exports = async (pr, context, settings) => {
+  let dependentSettings = settings.dependent
+  if (!dependentSettings) {
+    return {
+      mergeable: true,
+      description: 'Okay To Merge'
+    }
+  }
+
+  let dependentFiles = settings.dependent.files
+  let message = settings.dependent.message ||
+    'One of the following file is modified, all the other files in the list must be modified as well ' + dependentFiles.map(name => '\n  -' + name)
+
+  // fetch the file list
+  let result = await context.github.pullRequests.getFiles(context.repo({number: pr.number}))
+  let modifiedFiles = result.data.filter(file => file.status === 'modified').map(file => file.filename)
+
+  const fileDiff = _.difference(dependentFiles, modifiedFiles)
+
+  const isMergeable = dependentFiles.length === fileDiff.length || fileDiff.length === 0
+
+  return {
+    mergeable: isMergeable,
+    description: isMergeable ? 'Okay to merge' : message
+  }
+}

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -80,7 +80,7 @@ class Handler {
     let validators = []
     let excludes = (settings.exclude)
       ? settings.exclude.split(',').map(val => val.trim()) : []
-    let includes = [ 'approvals', 'title', 'label', 'milestone', 'description', 'projects', 'assignee' ]
+    let includes = [ 'approvals', 'title', 'label', 'milestone', 'description', 'projects', 'assignee', 'dependent' ]
       .filter(validator => excludes.indexOf(validator) === -1)
 
     includes.forEach(validator => {


### PR DESCRIPTION
Goals
---
This PR closes #36 

Details
---
- Added a validator that process on the `dependent` settings
- Wrote full unit test for the added files
- Tested Manually

The following settings can now be added to the configuration 
Note *** : this only work under `pull_requests:` setting
```
dependent:
  files: [] // list of file where if one is modified, all must be modified
  message: 'Custom message'
```