### PR TITLE
Bugfix: Stale Reminder Performance

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -1,3 +1,2 @@
 mergeable:
   approvals: 0
-  milestone: 'Version 1'

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -1,2 +1,3 @@
 mergeable:
   approvals: 0
+  milestone: 'Version 1.1'

--- a/index.js
+++ b/index.js
@@ -23,8 +23,9 @@ module.exports = (robot) => {
     (context) => { Handler.handleIssuesOpened(context) }
   )
 
-  // check every two seconds.
-  scheduler(robot, { interval: 60 * 60 * 2 })
+  // By default scan check every one hour.
+  // to debug locally you may want to change it to
+  // run on 2 sec interval like so: scheduler(robot, { interval: 60 * 60 * 2 })
   robot.on('schedule.repository',
     context => Handler.handleStale(context)
   )

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 const Handler = require('./lib/handler')
-const scheduler = require('probot-scheduler')
 
 module.exports = (robot) => {
   robot.on(
@@ -25,7 +24,8 @@ module.exports = (robot) => {
 
   // By default scan check every one hour.
   // to debug locally you may want to change it to
-  // run on 2 sec interval like so: scheduler(robot, { interval: 60 * 60 * 2 })
+  // run on 2 sec interval like so:
+  // const scheduler = require('probot-scheduler'); scheduler(robot, { interval: 60 * 60 * 2 })
   robot.on('schedule.repository',
     context => Handler.handleStale(context)
   )


### PR DESCRIPTION

We are scheduling checks to fetch every 2 seconds. That's too much. It will now just use the default of every 1 hour.

Every 2 secs will cause performance problems on first install into an org with a lot of repos.