### PR TITLE
add `and` and `or` sub options to processor

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -37,6 +37,12 @@ const processFilters = (validatorContext, input, filters) => {
       case 'required':
         output.push(required(validatorContext, input, filters[key]))
         break
+      case 'and':
+        output.push(andOr(validatorContext, input, filters))
+        break
+      case 'or':
+        output.push(andOr(validatorContext, input, filters))
+        break
       default:
         break
     }
@@ -229,6 +235,51 @@ const required = (validatorContext, input, filters) => {
   return {
     mergeable: isMergeable,
     description: isMergeable ? null : description
+  }
+}
+
+const andOr = (validatorContext, input, filters) => {
+  let filterArray
+  let andKey = true
+
+  if (filters.and) {
+    filterArray = filters.and
+  }
+
+  if (filters.or) {
+    filterArray = filters.or
+    andKey = false
+  }
+
+  const validated = filterArray.map(filter => {
+    if (filter.and || filter.or) {
+      return andOr(validatorContext, input, filter)
+    }
+    return processFilters(validatorContext, input, filter)
+  })
+
+  let isMergeable
+  let descriptions = ''
+
+  validated.forEach(result => {
+    if (isMergeable !== undefined) {
+      isMergeable = andKey ? isMergeable && result.mergeable : isMergeable || result.mergeable
+    } else {
+      isMergeable = result.mergeable
+    }
+
+    if (!result.mergeable) {
+      if (descriptions.length > 2) {
+        descriptions += ` ${andKey ? ` ***AND*** ` : ` ***OR*** `} ${result.description}`
+      } else {
+        descriptions += `${result.description}`
+      }
+    }
+  })
+
+  return {
+    mergeable: isMergeable,
+    description: isMergeable ? null : `(${descriptions})`
   }
 }
 


### PR DESCRIPTION
Goal 
---
closes #74 
This other validators such as description, title, reviewers, etc... 

Details 
---
example config:
``` 
    mergeable:
      pull_requests:
        label: 
          or: 
            - and: 
              - must_include:
                  regex: 'release note: yes'
                  message: 'Please include release note: yes'
              - must_include: 
                  regex: 'lang\\/core|lang\\/c\\+\\+|lang\\/c#'
                  message: 'Please include a language label'
            - must_include: 
                regex: 'release note: no'
                message: 'Please include release note: no'
```
example output : 
When non of the required label is set
![image](https://user-images.githubusercontent.com/5243508/43440738-408d5f02-944d-11e8-953b-938f9afeab55.png)


When only 'release note: yes' label is provided
![image](https://user-images.githubusercontent.com/5243508/43440697-1b0e642e-944d-11e8-8543-d4ce454b5312.png)

When only `lang/core` label is provided
![image](https://user-images.githubusercontent.com/5243508/43440717-2daa97ec-944d-11e8-91bc-e9f284e97fac.png)

