### PR TITLE
(bugfix) Start scheduler for stale 

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,12 @@
   <a href="https://github.com/apps/mergeable">
     <img src="https://img.shields.io/badge/FREE-INSTALL-orange.svg" alt="Free Install">
   </a>
-  <a href="https://circleci.com/gh/jusx/mergeable"><img src="https://circleci.com/gh/jusx/mergeable.svg?style=shield"></a>
+  <a href="https://gitter.im/mergeable-bot/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge">
+    <img src="https://badges.gitter.im/mergeable-bot/Lobby.svg">
+  </a>
+  <a href="https://circleci.com/gh/jusx/mergeable">
+    <img src="https://circleci.com/gh/jusx/mergeable.svg?style=shield">
+  </a>  
 </p>
 
 <p align="center">
@@ -229,10 +234,10 @@ Here's an example configuration file for advanced settings and all of it's possi
         min: 1
         max: 1
         message: 'Custom message...'
-      
+
       dependent:
         files: ['package.json', 'yarn.lock'] # list of files that all must be modified if one is modified
-        message: 'Custom message...' 
+        message: 'Custom message...'
 
     #####
     #  Advanced settings for issues. When any of the rules  below is not valid Mergeable will create a comment on that issue to let the author know.    

--- a/index.js
+++ b/index.js
@@ -28,7 +28,6 @@ module.exports = (robot) => {
   robot.on('schedule.repository',
     context => Handler.handleStale(context)
   )
-
 }
 
 const setup = (robot) => {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,9 @@
 const Handler = require('./lib/handler')
+const createScheduler = require('probot-scheduler')
 
 module.exports = (robot) => {
+  setup(robot)
+
   robot.on(
     [ 'pull_request.opened',
       'pull_request.edited',
@@ -22,11 +25,20 @@ module.exports = (robot) => {
     (context) => { Handler.handleIssuesOpened(context) }
   )
 
-  // By default scan check every one hour.
-  // to debug locally you may want to change it to
-  // run on 2 sec interval like so:
-  // const scheduler = require('probot-scheduler'); scheduler(robot, { interval: 60 * 60 * 2 })
   robot.on('schedule.repository',
     context => Handler.handleStale(context)
   )
+
+}
+
+const setup = (robot) => {
+  if (process.env.NODE_ENV === 'development') {
+    robot.log.info('In DEVELOPMENT mode.')
+    robot.log.info('Starting scheduler at 2 second intervals.')
+    createScheduler(robot, { interval: 60 * 60 * 2 })
+  } else {
+    robot.log.info('In PRODUCTION mode.')
+    robot.log.info('Starting scheduler at 1 hour intervals')
+    createScheduler(robot)
+  }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "ISC",
   "repository": "https://github.com/jusx/mergeable.git",
   "scripts": {
+    "dev": "NODE_ENV=development npm start",
     "start": "probot run ./index.js",
     "test": "jest && standard"
   },


### PR DESCRIPTION
### Goal
Fixes stale. The scheduler was commented out and hence it was not running stale.

### Changes
- Ensure scheduler is started.
- Added `dev` script to start with NODE_ENV set to development.
- scheduler is set to much shorter intervals in development to allow for debugging and testing.