### PR TITLE
Jusx/bugfix errors on schedule and event not in context pre validations

### DIFF
--- a/__tests__/configuration/configuration.test.js
+++ b/__tests__/configuration/configuration.test.js
@@ -7,8 +7,8 @@ describe('with flex', () => {
 
   test('it loads correctly without version', () => {
     let config = new Configuration()
-    expect(config.settings.mergeable[0].when).toBeDefined()
-    expect(config.settings.mergeable[0].validate).toBeDefined()
+    expect(config.settings[0].when).toBeDefined()
+    expect(config.settings[0].validate).toBeDefined()
   })
 
   test('it throw error correctly with wrong version specified', () => {

--- a/__tests__/flex.test.js
+++ b/__tests__/flex.test.js
@@ -46,19 +46,26 @@ describe('#executor', () => {
       validate: jest.fn(),
       isEventSupported: jest.fn().mockReturnValue(true)
     }
-    registry.validators.set('title', title)
     let label = {
       validate: jest.fn(),
       isEventSupported: jest.fn().mockReturnValue(true)
     }
-    registry.validators.set('label', label)
-
     registry.validators.set('title', title)
     registry.validators.set('label', label)
+
+    let checks = {
+      beforeValidate: jest.fn(),
+      afterValidate: jest.fn(),
+      isEventSupported: jest.fn().mockReturnValue(false)
+    }
+    registry.actions.set('checks', checks)
+
     await executor(context, registry)
 
     expect(title.validate).toHaveBeenCalledTimes(1)
     expect(label.validate).toHaveBeenCalledTimes(1)
+    expect(checks.beforeValidate).toHaveBeenCalledTimes(0)
+    expect(checks.afterValidate).toHaveBeenCalledTimes(0)
   })
 
   test('Comma seperated events', async () => {
@@ -88,15 +95,22 @@ describe('#executor', () => {
 
     let registry = { validators: new Map(), actions: new Map() }
     let title = {
-      validate: jest.fn(),
+      validate: jest.fn(value => Promise.resolve(value)),
       isEventSupported: jest.fn().mockReturnValue(true)
     }
     registry.validators.set('title', title)
     let issueOnly = {
-      validate: jest.fn(),
+      validate: jest.fn(value => Promise.resolve(value)),
       isEventSupported: jest.fn(event => { return (event === 'issues.opened') })
     }
     registry.validators.set('issueOnly', issueOnly)
+
+    let checks = {
+      beforeValidate: jest.fn(),
+      afterValidate: jest.fn(),
+      isEventSupported: jest.fn(event => { return (event === 'pull_request.opened') })
+    }
+    registry.actions.set('checks', checks)
 
     context.event = 'pull_request'
     context.payload.action = 'opened'
@@ -105,6 +119,8 @@ describe('#executor', () => {
     expect(title.isEventSupported).toHaveBeenCalledTimes(1)
     expect(issueOnly.validate).toHaveBeenCalledTimes(0)
     expect(issueOnly.isEventSupported).toHaveBeenCalledTimes(1)
+    expect(checks.beforeValidate).toHaveBeenCalledTimes(1)
+    expect(checks.afterValidate).toHaveBeenCalledTimes(1)
 
     context.event = 'issues'
     context.payload.action = 'opened'
@@ -113,6 +129,8 @@ describe('#executor', () => {
     expect(title.isEventSupported).toHaveBeenCalledTimes(2)
     expect(issueOnly.validate).toHaveBeenCalledTimes(1)
     expect(issueOnly.isEventSupported).toHaveBeenCalledTimes(2)
+    expect(checks.beforeValidate).toHaveBeenCalledTimes(1)
+    expect(checks.afterValidate).toHaveBeenCalledTimes(1)
   })
 
   test('Multiple Whens', async () => {
@@ -159,25 +177,35 @@ describe('#executor', () => {
 
     let registry = { validators: new Map(), actions: new Map() }
     let title = {
-      validate: jest.fn(),
+      validate: jest.fn(value => Promise.resolve(value)),
       isEventSupported: jest.fn().mockReturnValue(true)
     }
     registry.validators.set('title', title)
     let label = {
-      validate: jest.fn(),
+      validate: jest.fn(value => Promise.resolve(value)),
       isEventSupported: jest.fn().mockReturnValue(true)
     }
     registry.validators.set('label', label)
+    let checks = {
+      beforeValidate: jest.fn(),
+      afterValidate: jest.fn(),
+      isEventSupported: jest.fn().mockReturnValue(true)
+    }
+    registry.actions.set('checks', checks)
 
     context.event = 'pull_request'
     context.payload.action = 'opened'
     await executor(context, registry)
     expect(title.validate).toHaveBeenCalledTimes(1)
     expect(label.validate).toHaveBeenCalledTimes(0)
+    expect(checks.beforeValidate).toHaveBeenCalledTimes(1)
+    expect(checks.afterValidate).toHaveBeenCalledTimes(1)
 
     context.event = 'issues'
     await executor(context, registry)
     expect(title.validate).toHaveBeenCalledTimes(2)
     expect(label.validate).toHaveBeenCalledTimes(1)
+    expect(checks.beforeValidate).toHaveBeenCalledTimes(2)
+    expect(checks.afterValidate).toHaveBeenCalledTimes(2)
   })
 })

--- a/lib/actions/action.js
+++ b/lib/actions/action.js
@@ -1,4 +1,4 @@
-const { EventAware } = require('../eventAware')
+const EventAware = require('../eventAware')
 
 class Action extends EventAware {
   async beforeValidate () {

--- a/lib/configuration/configuration.js
+++ b/lib/configuration/configuration.js
@@ -4,19 +4,14 @@ const consts = require('./lib/consts')
 class Configuration {
   constructor (settings) {
     if (settings === undefined) {
-      this.settings = {}
-
-      if (this.isFlexVersion()) {
-        this.settings = {
-          mergeable: [{
-            when: 'pull_request.*',
-            validate: consts.DEFAULT_VALIDATE,
-            pass: consts.DEFAULT_PASS,
-            fail: consts.DEFAULT_FAIL,
-            error: consts.DEFAULT_ERROR
-          }]
-        }
-      }
+      this.settings = (this.isFlexVersion())
+        ? [{
+          when: 'pull_request.*',
+          validate: consts.DEFAULT_VALIDATE,
+          pass: consts.DEFAULT_PASS,
+          fail: consts.DEFAULT_FAIL,
+          error: consts.DEFAULT_ERROR
+        }] : {}
     } else {
       this.settings = yaml.safeLoad(settings)
       const version = this.checkConfigVersion()

--- a/lib/eventAware.js
+++ b/lib/eventAware.js
@@ -4,10 +4,12 @@ class EventAware {
    *  An event name to be evaluated for support. The name is as in the GitHub
    *  webhook format of issues.opened, pull_request.opened, etc
    *
-   * @return boolean true if the validator supports the event. i.e. issues.opened
+   * @return boolean true if the EventAware object supports the event. i.e. issues.opened
    */
   isEventSupported (eventName) {
-    return isEventInContext(eventName, this.supportedEvents)
+    let eventObject = eventName.split('.')[0]
+    let relevantEvent = this.supportedEvents.filter(event => event.split('.')[0] === eventObject)
+    return relevantEvent.indexOf(`${eventObject}.*`) > -1 || relevantEvent.indexOf(eventName) > -1
   }
 
   getPayload (context) {
@@ -15,14 +17,4 @@ class EventAware {
   }
 }
 
-const isEventInContext = (eventName, events) => {
-  let eventObject = eventName.split('.')[0]
-  let relevantEvent = events.filter(event => event.split('.')[0] === eventObject)
-
-  return relevantEvent.indexOf(`${eventObject}.*`) > -1 || relevantEvent.indexOf(eventName) > -1
-}
-
-module.exports = {
-  EventAware,
-  isEventInContext: isEventInContext
-}
+module.exports = EventAware

--- a/lib/flex.js
+++ b/lib/flex.js
@@ -9,19 +9,15 @@ const executeMergeable = async (context, registry) => {
 
   // first fetch the configuration
   let config = await Configuration.instanceWithContext(context)
-  context.log.debug(config)
 
   // go through the settings and register all the validators
   await config.registerValidatorsAndActions(registry)
-
-  // TODO isEventInContext should check for all rules againts current context event.
 
   // do pre validation actions
   await processPreActions(context, registry, config)
 
   // process each rule found in configuration
   config.settings.forEach(rule => {
-    context.log.debug('Processing rule: %j', rule)
     if (isEventInContext(rule.when, context)) {
       Promise.all(getValiatorPromises(context, registry, rule))
         .then((result) => {
@@ -41,7 +37,6 @@ const getValiatorPromises = (context, registry, rule) => {
 // call all action classes' beforeValidate, regardless of whether they are in failure or pass situation
 const processPreActions = async (context, registry, config) => {
   registry.actions.forEach(action => {
-    // TODO unit test that beforeValidate is not called when event is not supported.
     if (action.isEventSupported(`${context.event}.${context.payload.action}`)) {
       action.beforeValidate({ context })
     }
@@ -50,7 +45,6 @@ const processPreActions = async (context, registry, config) => {
 
 const getActionPromises = (context, registry, rule, result) => {
   const actions = rule[result.validationStatus]
-
   const afterValidateFuncCall = (actionClass, context, action, result) => actionClass.afterValidate(context, action, result)
 
   return createPromises(actions, 'actions', afterValidateFuncCall, context, registry, result)

--- a/lib/flex.js
+++ b/lib/flex.js
@@ -9,18 +9,23 @@ const executeMergeable = async (context, registry) => {
 
   // first fetch the configuration
   let config = await Configuration.instanceWithContext(context)
+  context.log.debug(config)
 
   // go through the settings and register all the validators
   await config.registerValidatorsAndActions(registry)
 
+  // TODO isEventInContext should check for all rules againts current context event.
+
   // do pre validation actions
   await processPreActions(context, registry, config)
+
+  // process each rule found in configuration
   config.settings.forEach(rule => {
+    context.log.debug('Processing rule: %j', rule)
     if (isEventInContext(rule.when, context)) {
       Promise.all(getValiatorPromises(context, registry, rule))
         .then((result) => {
           const translatedOutput = extractValidationStats(result)
-
           Promise.all(getActionPromises(context, registry, rule, translatedOutput))
         })
     }
@@ -36,7 +41,10 @@ const getValiatorPromises = (context, registry, rule) => {
 // call all action classes' beforeValidate, regardless of whether they are in failure or pass situation
 const processPreActions = async (context, registry, config) => {
   registry.actions.forEach(action => {
-    action.beforeValidate({ context })
+    // TODO unit test that beforeValidate is not called when event is not supported.
+    if (action.isEventSupported(`${context.event}.${context.payload.action}`)) {
+      action.beforeValidate({ context })
+    }
   })
 }
 

--- a/lib/validators/validator.js
+++ b/lib/validators/validator.js
@@ -1,4 +1,4 @@
-const { EventAware } = require('../eventAware')
+const EventAware = require('../eventAware')
 const options = require('./options_processor/options')
 
 const DEFAULT_SUPPORTED_OPTIONS = [


### PR DESCRIPTION
### Goals
Fix errors when stale is running and finds a repo with no configuration or with events that an action does not support.

### Changes
- Fix Configuration to instantiate with defaults correctly when `mergeable.yml` is not found.
- Fix `Action.beforeValidate()` calls to be made only when the event is supported. This was throwing errors before.
- Added tests for actions in execution.
- Remove redundant code in EventAware
