### PR TITLE
if event is pull_request, use the config file from head branch of PR

### DIFF
--- a/lib/configuration/configuration.js
+++ b/lib/configuration/configuration.js
@@ -133,7 +133,6 @@ class Configuration {
   }
 
   static instanceWithContext (context) {
-
     return Configuration.fetchConfigFile(context).then(res => {
       let content = Buffer.from(res.data.content, 'base64').toString()
 

--- a/lib/configuration/configuration.js
+++ b/lib/configuration/configuration.js
@@ -112,15 +112,29 @@ class Configuration {
     }
   }
 
-  static instanceWithContext (context) {
+  static fetchConfigFile (context) {
     let github = context.github
     let repo = context.repo()
 
-    return github.repos.getContent({
-      owner: repo.owner,
-      repo: repo.repo,
-      path: Configuration.FILE_NAME
-    }).then(res => {
+    if (context.event === 'pull_request') {
+      return github.repos.getContent({
+        owner: repo.owner,
+        repo: repo.repo,
+        path: Configuration.FILE_NAME,
+        ref: context.payload.pull_request.head.ref
+      })
+    } else {
+      return github.repos.getContent({
+        owner: repo.owner,
+        repo: repo.repo,
+        path: Configuration.FILE_NAME
+      })
+    }
+  }
+
+  static instanceWithContext (context) {
+
+    return Configuration.fetchConfigFile(context).then(res => {
       let content = Buffer.from(res.data.content, 'base64').toString()
 
       return new Configuration(content)

--- a/lib/dependent.js
+++ b/lib/dependent.js
@@ -22,6 +22,7 @@ module.exports = async (pr, context, settings) => {
 
   // fetch the file list
   let result = await context.github.pullRequests.getFiles(context.repo({number: pr.number}))
+
   let modifiedFiles = result.data.filter(file => file.status === 'modified').map(file => file.filename)
 
   const fileDiff = _.difference(dependentFiles, modifiedFiles)


### PR DESCRIPTION
Goal
---
When an Event is Pull_request, use the head branch's config file instead of the master branches

Context
---
This will allow user to test different settings and see how it works before merging it into the code base