### PR TITLE
Feature: Default Actions for V2 Config

### DIFF
--- a/__tests__/configuration/transformers/v2Config.test.js
+++ b/__tests__/configuration/transformers/v2Config.test.js
@@ -91,7 +91,7 @@ test('pass, fail, error defaults will load when pull_request is mixed with other
   expect(transformed.mergeable[0].error).toBeDefined()
 })
 
-test('pass, fail error defaults ignore recipes that are not for pull_requests', () => {
+test('only pass, fail defaults ignore recipes that are not for pull_requests', () => {
   let config = `
   version: 2
   mergeable:
@@ -106,5 +106,5 @@ test('pass, fail error defaults ignore recipes that are not for pull_requests', 
   console.log(transformed)
   expect(transformed.mergeable[0].pass).toBeUndefined()
   expect(transformed.mergeable[0].fail).toBeUndefined()
-  expect(transformed.mergeable[0].error).toBeUndefined()
+  expect(transformed.mergeable[0].error).toBeDefined()
 })

--- a/__tests__/configuration/transformers/v2Config.test.js
+++ b/__tests__/configuration/transformers/v2Config.test.js
@@ -103,8 +103,8 @@ test('only pass, fail defaults ignore recipes that are not for pull_requests', (
             message: 'This PR is work in progress.'
   `
   let transformed = V2Config.transform(yaml.safeLoad(config))
-  console.log(transformed)
+
   expect(transformed.mergeable[0].pass).toBeUndefined()
   expect(transformed.mergeable[0].fail).toBeUndefined()
-  expect(transformed.mergeable[0].error).toBeDefined()
+  expect(transformed.mergeable[0].error).toBeUndefined()
 })

--- a/__tests__/configuration/transformers/v2Config.test.js
+++ b/__tests__/configuration/transformers/v2Config.test.js
@@ -1,0 +1,110 @@
+const V2Config = require('../../../lib/configuration/transformers/v2Config')
+const yaml = require('js-yaml')
+
+test('pass, fail, error defaults will load when pull_request event is specified.', () => {
+  let config = `
+  version: 2
+  mergeable:
+    - when: pull_request.*
+      validate:
+        - do: title
+          must_exclude:
+            regex: 'wip|work in progress'
+            message: 'This PR is work in progress.'
+  `
+  let transformed = V2Config.transform(yaml.safeLoad(config))
+  console.log(transformed)
+  expect(transformed.mergeable[0].pass).toBeDefined()
+  expect(transformed.mergeable[0].fail).toBeDefined()
+  expect(transformed.mergeable[0].error).toBeDefined()
+})
+
+test('pass, fail, error defaults will load when pull_request event is specified and user specified configs are not overridden.', () => {
+  let config = `
+  version: 2
+  mergeable:
+    - when: pull_request.*
+      validate:
+        - do: title
+          must_exclude:
+            regex: 'wip|work in progress'
+            message: 'This PR is work in progress.'
+      pass:
+        - do: checks
+          state: completed
+          status: success
+          payload:
+            title: a title
+            summary: a summary
+            text: some text
+    `
+
+  let transformed = V2Config.transform(yaml.safeLoad(config))
+  expect(transformed.mergeable[0].pass[0].payload.title).toBe('a title')
+  expect(transformed.mergeable[0].fail).toBeDefined()
+  expect(transformed.mergeable[0].error).toBeDefined()
+
+  config = `
+  ${config}
+      fail:
+        - do: checks
+          state: completed
+          status: failure
+          payload:
+            title: a failed title
+  `
+  transformed = V2Config.transform(yaml.safeLoad(config))
+  expect(transformed.mergeable[0].pass[0].payload.title).toBe('a title')
+  expect(transformed.mergeable[0].fail[0].payload.title).toBe('a failed title')
+  expect(transformed.mergeable[0].error).toBeDefined()
+
+  config = `
+  ${config}
+      error:
+        - do: checks
+          state: completed
+          status: error
+          payload:
+            title: an errored title
+  `
+  transformed = V2Config.transform(yaml.safeLoad(config))
+  expect(transformed.mergeable[0].pass[0].payload.title).toBe('a title')
+  expect(transformed.mergeable[0].fail[0].payload.title).toBe('a failed title')
+  expect(transformed.mergeable[0].error[0].payload.title).toBe('an errored title')
+})
+
+test('pass, fail, error defaults will load when pull_request is mixed with other events.', () => {
+  let config = `
+  version: 2
+  mergeable:
+    - when: issues.*, pull_request.*
+      validate:
+        - do: title
+          must_exclude:
+            regex: 'wip|work in progress'
+            message: 'This PR is work in progress.'
+  `
+  let transformed = V2Config.transform(yaml.safeLoad(config))
+  console.log(transformed)
+  expect(transformed.mergeable[0].pass).toBeDefined()
+  expect(transformed.mergeable[0].fail).toBeDefined()
+  expect(transformed.mergeable[0].error).toBeDefined()
+})
+
+test('pass, fail error defaults ignore recipes that are not for pull_requests', () => {
+  let config = `
+  version: 2
+  mergeable:
+    - when: issues.*
+      validate:
+        - do: title
+          must_exclude:
+            regex: 'wip|work in progress'
+            message: 'This PR is work in progress.'
+  `
+  let transformed = V2Config.transform(yaml.safeLoad(config))
+  console.log(transformed)
+  expect(transformed.mergeable[0].pass).toBeUndefined()
+  expect(transformed.mergeable[0].fail).toBeUndefined()
+  expect(transformed.mergeable[0].error).toBeUndefined()
+})

--- a/lib/configuration/configuration.js
+++ b/lib/configuration/configuration.js
@@ -6,10 +6,10 @@ class Configuration {
     if (settings === undefined) {
       this.settings = [{
         when: 'pull_request.*',
-        validate: consts.DEFAULT_VALIDATE,
-        pass: consts.DEFAULT_PASS,
-        fail: consts.DEFAULT_FAIL,
-        error: consts.DEFAULT_ERROR
+        validate: consts.DEFAULT_PR_VALIDATE,
+        pass: consts.DEFAULT_PR_PASS,
+        fail: consts.DEFAULT_PR_FAIL,
+        error: consts.DEFAULT_PR_ERROR
       }]
     } else {
       this.settings = yaml.safeLoad(settings)

--- a/lib/configuration/lib/consts.js
+++ b/lib/configuration/lib/consts.js
@@ -1,7 +1,7 @@
 module.exports = {
   CONFIGURATION_FILE_PATH: '.github/mergeable.yml',
   ERROR_INVALID_YML: 'Invalid mergeable YML file format. Root mergeable node is missing.',
-  DEFAULT_PASS: [{
+  DEFAULT_PR_PASS: [{
     do: 'checks',
     state: 'completed',
     status: 'success',
@@ -10,15 +10,15 @@ module.exports = {
       summary: `All the validators have return 'pass'! \n Here are some stats of the run: \n {{validationCount}} validations were ran`
     }
   }],
-  DEFAULT_FAIL: [{
+  DEFAULT_PR_FAIL: [{
     do: 'checks',
     state: 'completed',
     status: 'failure',
     payload: {
       title: `Mergeable run returned Status ***{{toUpperCase validationStatus}}***`,
       summary: `### Status: {{toUpperCase validationStatus}}
-       
-        Here are some stats of the run: 
+
+        Here are some stats of the run:
         {{validationCount}} validations were ran.
         {{passCount}} PASSED
         {{failCount}} FAILED
@@ -32,7 +32,7 @@ module.exports = {
 {{/each}}`
     }
   }],
-  DEFAULT_ERROR: [{
+  DEFAULT_PR_ERROR: [{
     do: 'checks',
     state: 'completed',
     status: 'action_required',
@@ -52,7 +52,7 @@ Status {{toUpperCase status}}
 {{/each}}`
     }
   }],
-  DEFAULT_VALIDATE: [{
+  DEFAULT_PR_VALIDATE: [{
     do: 'title',
     must_exclude: {
       regex: 'wip|dnm|exp|poc'

--- a/lib/configuration/transformers/v1Config.js
+++ b/lib/configuration/transformers/v1Config.js
@@ -68,7 +68,7 @@ const processValidators = (event, config) => {
     return Object.assign(value, {'do': validator})
   })
 
-  return { when: event, validate, pass: consts.DEFAULT_PASS, fail: consts.DEFAULT_FAIL, error: consts.DEFAULT_ERROR }
+  return { when: event, validate, pass: consts.DEFAULT_PR_PASS, fail: consts.DEFAULT_PR_FAIL, error: consts.DEFAULT_PR_ERROR }
 }
 
 module.exports = V1Config

--- a/lib/configuration/transformers/v2Config.js
+++ b/lib/configuration/transformers/v2Config.js
@@ -13,15 +13,14 @@ const setPullRequestDefault = (config) => {
   config.mergeable.forEach((recipe) => {
     if (recipe.when.includes('pull_request')) {
       if (recipe.pass === undefined) {
-        recipe.pass = consts.DEFAULT_PASS
+        recipe.pass = consts.DEFAULT_PR_PASS
       }
       if (recipe.fail === undefined) {
-        recipe.fail = consts.DEFAULT_FAIL
+        recipe.fail = consts.DEFAULT_PR_FAIL
       }
-    }
-
-    if (recipe.error === undefined) {
-      recipe.error = consts.DEFAULT_ERROR
+      if (recipe.error === undefined) {
+        recipe.error = consts.DEFAULT_PR_ERROR
+      }
     }
   })
 }

--- a/lib/configuration/transformers/v2Config.js
+++ b/lib/configuration/transformers/v2Config.js
@@ -18,9 +18,10 @@ const setPullRequestDefault = (config) => {
       if (recipe.fail === undefined) {
         recipe.fail = consts.DEFAULT_FAIL
       }
-      if (recipe.error === undefined) {
-        recipe.error = consts.DEFAULT_ERROR
-      }
+    }
+
+    if (recipe.error === undefined) {
+      recipe.error = consts.DEFAULT_ERROR
     }
   })
 }

--- a/lib/configuration/transformers/v2Config.js
+++ b/lib/configuration/transformers/v2Config.js
@@ -1,8 +1,27 @@
+const _ = require('lodash')
+const consts = require('../lib/consts')
+
 class V2Config {
   static transform (config) {
-    // @todo write transform logic for version 2
-    return config
+    let transformedConfig = _.cloneDeep(config)
+    setPullRequestDefault(transformedConfig)
+    return transformedConfig
   }
 }
 
+const setPullRequestDefault = (config) => {
+  config.mergeable.forEach((recipe) => {
+    if (recipe.when.includes('pull_request')) {
+      if (recipe.pass === undefined) {
+        recipe.pass = consts.DEFAULT_PASS
+      }
+      if (recipe.fail === undefined) {
+        recipe.fail = consts.DEFAULT_FAIL
+      }
+      if (recipe.error === undefined) {
+        recipe.error = consts.DEFAULT_ERROR
+      }
+    }
+  })
+}
 module.exports = V2Config


### PR DESCRIPTION
### Goal
- Feature: To ensure that there are default `pass`, `fail`, `error` actions for pull_request recipes.
- Refactor: Rename constant so that it is clear it's for `pull_request` events only.
