### PR TITLE
Fix approvals for when ownersfile does not exist

### DIFF
--- a/__fixtures__/helper.js
+++ b/__fixtures__/helper.js
@@ -1,3 +1,9 @@
+const throwNotFound = () => {
+  let error = new Error('404 error')
+  error.code = 404
+  throw error
+}
+
 module.exports = {
   mockContext: (options) => {
     if (!options) options = {}
@@ -38,15 +44,13 @@ module.exports = {
           getContent: ({ path }) => {
             return new Promise((resolve, reject) => {
               if (path === '.github/mergeable.yml') {
-                let error = new Error('404 error')
-                error.code = 404
-                throw error
+                throwNotFound()
               }
 
               if (path === '.github/CODEOWNERS') {
                 return options.codeowners ? resolve({ data: {
                   content: options.codeowners
-                }}) : resolve()
+                }}) : throwNotFound()
               }
             })
           },
@@ -119,5 +123,4 @@ module.exports = {
       })
     }
   }
-
 }

--- a/__tests__/validators/approvals.test.js
+++ b/__tests__/validators/approvals.test.js
@@ -1,6 +1,18 @@
 const Helper = require('../../__fixtures__/helper')
 const Approval = require('../../lib/validators/approvals')
 
+test.only('that approvals work with no owners file', async () => {
+  const approval = new Approval()
+  const settings = {
+    do: 'approval',
+    min: {
+      count: 2
+    }
+  }
+  let validation = await approval.validate(createMockContext(1, null, null, null, true), settings)
+  expect(validation.status).toBe('fail')
+})
+
 test('that mergeable is false when less than minimum', async () => {
   const approval = new Approval()
   const settings = {
@@ -261,7 +273,7 @@ const createCommitDiffs = (diffs) => {
   }))
 }
 
-const createMockContext = (minimum, data, owners, commitDiffs) => {
+const createMockContext = (minimum, data, owners, commitDiffs, isOwnersNotFound = false) => {
   if (!data) {
     data = []
     for (let i = 0; i < minimum; i++) {
@@ -275,7 +287,8 @@ const createMockContext = (minimum, data, owners, commitDiffs) => {
     }
   }
 
-  return Helper.mockContext({reviews: data, codeowners: Buffer.from(`${owners}`).toString('base64'), compareCommits: commitDiffs})
+  let codeowners = (isOwnersNotFound) ? null : Buffer.from(`${owners}`).toString('base64')
+  return Helper.mockContext({reviews: data, codeowners: codeowners, compareCommits: commitDiffs})
 }
 
 const createReviewList = (reviewers) => {

--- a/lib/validators/options_processor/owners.js
+++ b/lib/validators/options_processor/owners.js
@@ -3,7 +3,7 @@ const gitPattern = require('./gitPattern')
 class Owner {
   static async process (payload, context) {
     const CODEOWNERS = await retrieveCODEOWNER(context)
-    if (CODEOWNERS === 'undefined') return []
+    if (CODEOWNERS === null) return []
 
     const owners = gitPattern.parseOwnerFile(CODEOWNERS)
 
@@ -48,7 +48,7 @@ const retrieveCODEOWNER = async (context) => {
   })).then(res => {
     return Buffer.from(res.data.content, 'base64').toString()
   }).catch(error => {
-    if (error.code === 404) return false
+    if (error.code === 404) return null
     else throw error
   })
 }


### PR DESCRIPTION
### Goal
- Owners file may not exist but in `flex` mergeable crashes. Handle the case where there's no owners file properly.
- Add test for when there is no owners file.
