### PR TITLE
fix: The project validator looking at the wrong setting

### DIFF
--- a/__tests__/validators/project.test.js
+++ b/__tests__/validators/project.test.js
@@ -1,43 +1,34 @@
 const Project = require('../../lib/validators/project')
 const Helper = require('../../__fixtures__/helper')
 
-test('that mergeable is true when PR number is in Project', async () => {
-  const projects = new Project()
-  const settings = {
-    do: 'project',
+const settings = {
+  do: 'project',
+  must_include: {
     regex: 'Project One'
   }
+}
+
+test('that mergeable is true when PR number is in Project', async () => {
+  const projects = new Project()
   let validation = await projects.validate(createMockContext({number: 1}), settings)
   expect(validation.status).toBe('pass')
 })
 
 test('that mergeable is false when PR number is not in Project', async () => {
   const projects = new Project()
-  const settings = {
-    do: 'project',
-    regex: 'Project One'
-  }
   let validation = await projects.validate(createMockContext({number: 3}), settings)
   expect(validation.status).toBe('fail')
 })
 
 test('test description is correct', async () => {
   const projects = new Project()
-  const settings = {
-    do: 'project',
-    regex: 'Project One'
-  }
   let validation = await projects.validate(createMockContext({number: 3}), settings)
   expect(validation.status).toBe('fail')
-  expect(validation.validations[0].description).toBe('Must be in "Project One" Project')
+  expect(validation.validations[0].description).toBe('Must be in the "Project One" project.')
 })
 
 test('test deep validation works', async () => {
   const projects = new Project()
-  const settings = {
-    do: 'project',
-    regex: 'Project One'
-  }
   let validation = await projects.validate(createMockContext({number: 3, description: 'closes #1'}), settings)
   expect(validation.status).toBe('pass')
   expect(validation.validations[0].description).toBe('Required Project is present')

--- a/lib/validators/project.js
+++ b/lib/validators/project.js
@@ -96,7 +96,7 @@ const getProjectCards = async (context, projIds) => {
       cards = cards.concat(card.data)
     })
   }
-  console.log('cards' + cards)
+
   return cards.map(card => card.content_url)
 }
 

--- a/lib/validators/project.js
+++ b/lib/validators/project.js
@@ -26,15 +26,15 @@ class Project extends Validator {
 
   async validate (context, validationSettings) {
     const pr = this.getPayload(context)
-    let projectName = validationSettings.regex
+    let projectName = validationSettings.must_include &&
+      validationSettings.must_include.regex
 
     const MATCH_NOT_FOUND_ERROR = `Failed to run the test because 'match' is not provided for 'project' option. Please check README for more information about configuration`
     const DEFUALT_SUCCESS_MESSAGE = 'Required Project is present'
     let description = validationSettings.message ||
-      `Must be in "${validationSettings.regex}" Project`
+      `Must be in the "${projectName}" project.`
 
     let projects = await getProjects(context)
-
     const validatorContext = {name: 'project'}
     if (!projectName) {
       return consolidateResult([constructError('project', projects, validationSettings, MATCH_NOT_FOUND_ERROR)], validatorContext)
@@ -42,7 +42,7 @@ class Project extends Validator {
 
     const regex = new RegExp(projectName, 'i')
 
-    let projIds = projects.filter(project => regex.test(project.name))
+    let projIds = projects.filter(project => regex.test(project.name)).map(project => project.id)
     let projectCards = await getProjectCards(context, projIds)
     const idsFromCards = extractIssueIdsFromCards(pr, projectCards)
     let isMergeable = idsFromCards.includes(String(pr.number))
@@ -96,7 +96,7 @@ const getProjectCards = async (context, projIds) => {
       cards = cards.concat(card.data)
     })
   }
-
+  console.log('cards' + cards)
   return cards.map(card => card.content_url)
 }
 


### PR DESCRIPTION
### Goal
Fix the project validator to look at the correct setting `must_include.regex`

### Changes
- Updated unit test to have the correct fixture.
- Updated `Project` validator to look at the correct setting for regex and proper filtering of project ids.
- Updated default message for minor grammar correction.