### PR TITLE
fix: stale

### DIFF
--- a/__tests__/actions/comment.test.js
+++ b/__tests__/actions/comment.test.js
@@ -1,7 +1,6 @@
 const Comment = require('../../lib/actions/comment')
 const Helper = require('../../__fixtures__/helper')
 
-// TODO(stale): update tests to include scheduled context executions.
 const settings = {
   payload: {
     body: `Your run has returned the following status: {{status}}`

--- a/__tests__/actions/comment.test.js
+++ b/__tests__/actions/comment.test.js
@@ -1,24 +1,42 @@
 const Comment = require('../../lib/actions/comment')
 const Helper = require('../../__fixtures__/helper')
 
-test('check that comment created when doPostAction is called with proper parameter', async () => {
+// TODO(stale): update tests to include scheduled context executions.
+const settings = {
+  payload: {
+    body: `Your run has returned the following status: {{status}}`
+  }
+}
+
+let result = {
+  status: 'pass',
+  validations: [{
+    status: 'pass',
+    name: 'Label'
+  }]
+}
+
+test('check that comment created when afterValidate is called with proper parameter', async () => {
   const comment = new Comment()
   const context = createMockContext()
-  const result = {
-    status: 'pass',
-    validations: [{
-      status: 'pass',
-      name: 'Label'
-    }]
-  }
-  const settings = {
-    payload: {
-      body: `Your run has returned the following status: {{status}}`
-    }
-  }
+
   await comment.afterValidate(context, settings, result)
   expect(context.github.issues.createComment.mock.calls.length).toBe(1)
   expect(context.github.issues.createComment.mock.calls[0][0].body).toBe(`Your run has returned the following status: pass`)
+})
+
+test('that comment is created three times when result contain three issues found to be acted on', async () => {
+  const comment = new Comment()
+  const context = createMockContext()
+
+  result.validationSuites = [{
+    schedule: {
+      issues: [{number: 1}, {number: 2}, {number: 3}],
+      pulls: []
+    }
+  }]
+  await comment.afterValidate(context, settings, result)
+  expect(context.github.issues.createComment.mock.calls.length).toBe(3)
 })
 
 const createMockContext = () => {

--- a/__tests__/configuration/configuration.test.js
+++ b/__tests__/configuration/configuration.test.js
@@ -131,7 +131,7 @@ describe('with version 1', () => {
     expect(validate.find(e => e.do === 'label').must_exclude.regex).toBe('label regex')
   })
 
-  test.only('that defaults load correctly when mergeable is null', () => {
+  test('that defaults load correctly when mergeable is null', () => {
     let config = new Configuration(`mergeable:`)
     let validate = config.settings[0].validate
 
@@ -213,10 +213,11 @@ describe('with version 1', () => {
     `)
 
     await Configuration.instanceWithContext(context).then(config => {
-      let validate = config.settings[0].validate
-      expect(validate.find(e => e.do === 'stale') !== undefined).toBe(true)
-      expect(validate.find(e => e.do === 'stale').days).toBe(20)
-      expect(validate.find(e => e.do === 'stale').message).toBe(Configuration.DEFAULTS.stale.message)
+      let when = config.settings[2]
+      expect(when.validate[0].do).toBe('stale')
+      expect(when.validate[0].days).toBe(20)
+      expect(when.pass[0].do).toBe('comment')
+      expect(when.pass[0].payload.body).toBe(Configuration.DEFAULTS.stale.message)
     })
 
     context = createMockGhConfig(`
@@ -227,10 +228,11 @@ describe('with version 1', () => {
     `)
 
     await Configuration.instanceWithContext(context).then(config => {
-      let validate = config.settings[0].validate
-      expect(validate.find(e => e.do === 'stale') !== undefined).toBe(true)
-      expect(validate.find(e => e.do === 'stale').days).toBe(20)
-      expect(validate.find(e => e.do === 'stale').message).toBe(Configuration.DEFAULTS.stale.message)
+      let when = config.settings[1]
+      expect(when.validate[0].do).toBe('stale')
+      expect(when.validate[0].days).toBe(20)
+      expect(when.pass[0].do).toBe('comment')
+      expect(when.pass[0].payload.body).toBe(Configuration.DEFAULTS.stale.message)
     })
 
     context = createMockGhConfig(`
@@ -246,15 +248,19 @@ describe('with version 1', () => {
     `)
 
     await Configuration.instanceWithContext(context).then(config => {
-      let issueValidate = config.settings[0].validate
-      let pullValidate = config.settings[1].validate
+      let issueWhen = config.settings[1]
+      let pullWhen = config.settings[4]
 
-      expect(config.settings[0].when).toBe('issues.*')
-      expect(config.settings[1].when).toBe('pull_request.*')
-      expect(issueValidate.find(e => e.do === 'stale') !== undefined).toBe(true)
-      expect(issueValidate.find(e => e.do === 'stale').days).toBe(20)
-      expect(issueValidate.find(e => e.do === 'stale').message).toBe('Issue test')
-      expect(pullValidate.find(e => e.do === 'stale').message).toBe('PR test')
+      expect(issueWhen.when).toBe('schedule.repository')
+      expect(pullWhen.when).toBe('schedule.repository')
+      expect(issueWhen.validate[0].do).toBe('stale')
+      expect(issueWhen.validate[0].days).toBe(20)
+      expect(issueWhen.pass[0].do).toBe('comment')
+      expect(issueWhen.pass[0].payload.body).toBe('Issue test')
+      expect(pullWhen.validate[0].do).toBe('stale')
+      expect(pullWhen.validate[0].days).toBe(20)
+      expect(pullWhen.pass[0].do).toBe('comment')
+      expect(pullWhen.pass[0].payload.body).toBe('PR test')
     })
   })
 

--- a/__tests__/configuration/configuration.test.js
+++ b/__tests__/configuration/configuration.test.js
@@ -131,13 +131,13 @@ describe('with version 1', () => {
     expect(validate.find(e => e.do === 'label').must_exclude.regex).toBe('label regex')
   })
 
-  test('that defaults load correctly when mergeable is null', () => {
+  test.only('that defaults load correctly when mergeable is null', () => {
     let config = new Configuration(`mergeable:`)
     let validate = config.settings[0].validate
 
     expect(validate.find(e => e.do === 'title').must_exclude.regex).toBe(Configuration.DEFAULTS.title)
     expect(validate.find(e => e.do === 'label').must_exclude.regex).toBe(Configuration.DEFAULTS.label)
-    expect(validate.find(e => e.do === 'stale').message).toBe(Configuration.DEFAULTS.stale.message)
+    expect(validate.find(e => e.do === 'stale')).toBeUndefined()
   })
 
   test('that defaults load correctly when mergeable has partial properties defined', () => {

--- a/__tests__/validators/stale.test.js
+++ b/__tests__/validators/stale.test.js
@@ -34,7 +34,7 @@ test('will set the issues and pulls appropriately when no type is set', async ()
   expect(results.schedule.pulls.length).toBe(1)
 })
 
-test('will set the issues and pulls even when unsupported type is set -- nothing', async () => {
+test('will set the issues and pulls even when unsupported type is set', async () => {
   let settings = { do: 'stale', days: 10, type: ['junk1', 'junk2'] }
 
   let stale = new Stale()
@@ -45,14 +45,13 @@ test('will set the issues and pulls even when unsupported type is set -- nothing
 
   let results = await stale.validate(context, settings)
   let callParam = context.github.search.issues.mock.calls
-  expect(callParam[0][0].type).toBeUndefined()
+  expect(callParam[0][0].q.includes('type')).toBeFalsy()
   expect(results.schedule.issues).toBeDefined()
   expect(results.schedule.pulls).toBeDefined()
 
   settings.type = ['junk', 'issues']
   results = await stale.validate(context, settings)
-
-  expect(callParam[1][0].type).toBeUndefined()
+  expect(callParam[1][0].q.includes('type:issues')).toBeTruthy()
   expect(results.schedule.issues).toBeDefined()
   expect(results.schedule.pulls).toBeDefined()
 })

--- a/__tests__/validators/stale.test.js
+++ b/__tests__/validators/stale.test.js
@@ -95,12 +95,5 @@ const createMockContext = (results) => {
       data: { items: results }
     })
   }
-
-  // context.github.search = {
-  //   issues: jest.fn(p => {
-  //     return { data: { items: results } }
-  //   })
-  // }
-
   return context
 }

--- a/__tests__/validators/stale.test.js
+++ b/__tests__/validators/stale.test.js
@@ -1,89 +1,88 @@
 const Helper = require('../../__fixtures__/helper')
 const Stale = require('../../lib/validators/stale')
 
-test('will create comment when configured and stale pulls are found.', async () => {
-  const stale = new Stale()
-  const context = createMockContextWithPullsSetting([{number: 1}])
-  const config = {
+test('will set the issues and pulls appropriately when both types are specified', async () => {
+  let settings = {
     do: 'stale',
-    days: 20
+    days: 10,
+    type: ['issues', 'pull_request']
   }
 
-  await stale.validate(context, config)
-  expect(context.github.issues.createComment.mock.calls.length).toBe(1)
+  let stale = new Stale()
+  let context = createMockContext([
+      { number: 1 },
+      { number: 2, pull_request: {} }
+  ])
+
+  let results = await stale.validate(context, settings)
+
+  expect(results.schedule.issues.length).toBe(1)
+  expect(results.schedule.pulls.length).toBe(1)
 })
 
-test('will create comment when configured and stale issues are found.', async () => {
-  const stale = new Stale()
-  let context = createMockContextWithIssueSetting([{number: 1}])
-  let config = {
+test('will set the issues and pulls appropriately when no type is set', async () => {
+  let settings = { do: 'stale', days: 10 }
+
+  let stale = new Stale()
+  let context = createMockContext([
+      { number: 1 },
+      { number: 2, pull_request: {} }
+  ])
+
+  let results = await stale.validate(context, settings)
+  expect(results.schedule.issues.length).toBe(1)
+  expect(results.schedule.pulls.length).toBe(1)
+})
+
+test('will set the issues and pulls appropriately when unsupported type is set', async () => {
+  let settings = { do: 'stale', days: 10, types: ['junk1', 'junk2'] }
+
+  let stale = new Stale()
+  let context = createMockContext([
+      { number: 1 },
+      { number: 2, pull_request: {} }
+  ])
+
+  let results = await stale.validate(context, settings)
+  expect(results.schedule.issues.length).toBe(1)
+  expect(results.schedule.pulls.length).toBe(1)
+
+  settings.types = ['issues', 'junk']
+  results = await stale.validate(context, settings)
+  expect(results.schedule.issues.length).toBe(1)
+  expect(results.schedule.pulls.length).toBe(0)
+})
+
+test.only('will set the issues and pulls correctly when type is issue only', async () => {
+  let settings = {
     do: 'stale',
-    days: 20
+    days: 10,
+    type: 'issues'
   }
 
-  await stale.validate(context, config)
-  expect(context.github.issues.createComment.mock.calls.length).toBe(1)
+  let stale = new Stale()
+  let context = createMockContext([{ number: 1 }])
+
+  let res = await stale.validate(context, settings)
+
+  expect(res.schedule.issues.length).toBe(1)
+  expect(res.schedule.pulls.length).toBe(0)
 })
 
-test('will create comment when configured issues are found and multiple issues are found.', async () => {
-  const stale = new Stale()
-  let context = createMockContextWithIssueSetting([{number: 1}, {number: 2}])
-  let config = {
+test('will set the issues and pulls correctly when type is pull_request only', async () => {
+  let settings = {
     do: 'stale',
-    days: 20
+    days: 10,
+    type: 'pull_request'
   }
 
-  await stale.validate(context, config)
-  expect(context.github.issues.createComment.mock.calls.length).toBe(2)
+  let stale = new Stale()
+  let context = createMockContext([{ number: 1, pull_reqwuest: {} }])
+
+  let res = await stale.validate(context, settings)
+  expect(res.schedule.pulls.length).toBe(1)
+  expect(res.schedule.issues.length).toBe(0)
 })
-
-test('will NOT create comment when configured and stale pulls are not found.', async () => {
-  const stale = new Stale()
-  let context = createMockContextWithIssueSetting([])
-  let config = {
-    do: 'stale',
-    days: 20
-  }
-
-  await stale.validate(context, config)
-  expect(context.github.issues.createComment.mock.calls.length).toBe(0)
-})
-
-test('will NOT create comment when configured and stale issues are not found.', async () => {
-  const stale = new Stale()
-  let context = createMockContextWithPullsSetting([])
-  let config = {
-    do: 'stale',
-    days: 20
-  }
-
-  await stale.validate(context, config)
-  expect(context.github.issues.createComment.mock.calls.length).toBe(0)
-})
-
-const createMockContextWithIssueSetting = (results) => {
-  let context = createMockContext(results)
-  Helper.mockConfigWithContext(context, `
-    mergeable:
-      issues:
-        stale:
-          days: 20
-    `)
-
-  return context
-}
-
-const createMockContextWithPullsSetting = (results) => {
-  let context = createMockContext(results)
-  Helper.mockConfigWithContext(context, `
-    mergeable:
-      pull_requests:
-        stale:
-          days: 20
-    `)
-
-  return context
-}
 
 const createMockContext = (results) => {
   let context = Helper.mockContext()
@@ -93,7 +92,5 @@ const createMockContext = (results) => {
       data: { items: results }
     })
   }
-
-  context.github.issues.createComment = jest.fn()
   return context
 }

--- a/lib/actions/comment.js
+++ b/lib/actions/comment.js
@@ -2,7 +2,6 @@ const { Action } = require('./action')
 const populateTemplate = require('./handlebars/populateTemplate')
 
 const createComment = async (context, number, body) => {
-  console.log(number, body)
   return context.github.issues.createComment(
     context.repo({ number, body })
   )

--- a/lib/actions/comment.js
+++ b/lib/actions/comment.js
@@ -1,7 +1,8 @@
 const { Action } = require('./action')
 const populateTemplate = require('./handlebars/populateTemplate')
 
-const createComments = async (context, number, body) => {
+const createComment = async (context, number, body) => {
+  console.log(number, body)
   return context.github.issues.createComment(
     context.repo({ number, body })
   )
@@ -12,24 +13,29 @@ class Comment extends Action {
     super()
     this.supportedEvents = [
       'pull_request.*',
-      'issues.*'
+      'issues.*',
+      'schedule.repository'
     ]
   }
 
   // there is nothing to do
   async beforeValidate () {}
 
-  populatePayloadWithResult (settings, results) {
-    return populateTemplate(settings.payload.body, results)
-  }
-
   async afterValidate (context, settings, results) {
-    const payload = this.populatePayloadWithResult(settings, results)
+    let scheduleResults = results.validationSuites && results.validationSuites[0].schedule
+    let commentables = (scheduleResults)
+      ? scheduleResults.issues.concat(scheduleResults.pulls)
+      : [this.getPayload(context)]
 
-    await createComments(
-      context,
-      this.getPayload(context).number,
-      payload)
+    return Promise.all(
+      commentables.map(issue => {
+        createComment(
+          context,
+          issue.number,
+          populateTemplate(settings.payload.body, results)
+        )
+      })
+    )
   }
 }
 

--- a/lib/configuration/configuration.js
+++ b/lib/configuration/configuration.js
@@ -143,7 +143,10 @@ Configuration.ERROR_INVALID_YML = 'Invalid mergeable YML file format. Root merge
 Configuration.UNKNOWN_VERSION_ERROR = 'Invalid version provided! please check README to check all the supported Versions!'
 Configuration.DEFAULTS = {
   label: 'work in progress|do not merge|experimental|proof of concept',
-  title: 'wip|dnm|exp|poc'
+  title: 'wip|dnm|exp|poc',
+  stale: {
+    message: 'There haven\'t been much activity here. This is stale. Is it still relevant? This is a friendly reminder to please resolve it. :-)'
+  }
 }
 
 module.exports = Configuration

--- a/lib/configuration/configuration.js
+++ b/lib/configuration/configuration.js
@@ -96,18 +96,6 @@ class Configuration {
         this.settings.mergeable[key] = Configuration.DEFAULTS[key]
       }
     }
-
-    // ensure stale defaults
-    if (this.settings.mergeable.pull_requests &&
-      this.settings.mergeable.pull_requests.stale &&
-      this.settings.mergeable.pull_requests.stale.message === undefined) {
-      this.settings.mergeable.pull_requests.stale.message = Configuration.DEFAULTS.stale.message
-    }
-    if (this.settings.mergeable.issues &&
-      this.settings.mergeable.issues.stale &&
-      this.settings.mergeable.issues.stale.message === undefined) {
-      this.settings.mergeable.issues.stale.message = Configuration.DEFAULTS.stale.message
-    }
   }
 
   static async fetchConfigFile (context) {
@@ -155,10 +143,7 @@ Configuration.ERROR_INVALID_YML = 'Invalid mergeable YML file format. Root merge
 Configuration.UNKNOWN_VERSION_ERROR = 'Invalid version provided! please check README to check all the supported Versions!'
 Configuration.DEFAULTS = {
   label: 'work in progress|do not merge|experimental|proof of concept',
-  title: 'wip|dnm|exp|poc',
-  stale: {
-    message: 'There haven\'t been much activity here. This is stale. Is it still relevant? This is a friendly reminder to please resolve it. :-)'
-  }
+  title: 'wip|dnm|exp|poc'
 }
 
 module.exports = Configuration

--- a/lib/configuration/transformers/v1Config.js
+++ b/lib/configuration/transformers/v1Config.js
@@ -35,18 +35,34 @@ class V1Config {
 
     if (config.issues) {
       output.push(processValidators('issues.*', config.issues, {pass: [], fail: consts.DEFAULT_ISSUES_FAIL, error: consts.DEFAULT_ISSUES_ERROR}))
+      processStale('issues', config.issues, output)
     }
 
     if (config.pull_requests) {
       output.push(processValidators('pull_request.*', config.pull_requests, {pass: consts.DEFAULT_PR_PASS, fail: consts.DEFAULT_PR_FAIL, error: consts.DEFAULT_PR_ERROR}))
       output.push(processValidators('pull_request_review.*', config.pull_requests, {pass: consts.DEFAULT_PR_PASS, fail: consts.DEFAULT_PR_FAIL, error: consts.DEFAULT_PR_ERROR}))
+      processStale('pull_request', config.pull_requests, output)
     }
     if (!config.pull_requests && !config.issues) {
       output.push(processValidators('pull_request.*', config, {pass: consts.DEFAULT_PR_PASS, fail: consts.DEFAULT_PR_FAIL, error: consts.DEFAULT_PR_ERROR}))
       output.push(processValidators('pull_request_review.*', config, {pass: consts.DEFAULT_PR_PASS, fail: consts.DEFAULT_PR_FAIL, error: consts.DEFAULT_PR_ERROR}))
     }
-
     return {mergeable: output}
+  }
+}
+
+const processStale = (type, config, output) => {
+  const stale = config.stale
+  if (stale) {
+    output.push({
+      when: 'schedule.repository',
+      validate: [{
+        do: 'stale',
+        days: stale.days,
+        type: type
+      }],
+      pass: [ { do: 'comment', payload: { body: stale.message } } ]
+    })
   }
 }
 
@@ -61,7 +77,7 @@ const processValidators = (event, config, options) => {
     })
   }
 
-  const validate = Object.keys(config).map(validator => {
+  const validate = Object.keys(config).filter(validator => validator !== 'stale').map(validator => {
     const value = config[validator]
 
     if (typeof value !== 'object') {

--- a/lib/configuration/transformers/v1Config.js
+++ b/lib/configuration/transformers/v1Config.js
@@ -1,4 +1,5 @@
 const consts = require('../lib/consts')
+const Configuration = require('../configuration')
 
 const simpleConfigMapping = {
   assignee: (num) => ({do: 'assignee',
@@ -61,7 +62,7 @@ const processStale = (type, config, output) => {
         days: stale.days,
         type: type
       }],
-      pass: [ { do: 'comment', payload: { body: stale.message } } ]
+      pass: [ { do: 'comment', payload: { body: stale.message || Configuration.DEFAULTS.stale.message } } ]
     })
   }
 }

--- a/lib/validators/stale.js
+++ b/lib/validators/stale.js
@@ -18,7 +18,7 @@ class Stale extends Validator {
       typeSetting.filter(type => type === 'issues' || type === 'pull_request')
     types = types || [typeSetting]
 
-    let typeQuery = (types.lenth === 1) ? ` type:${types[0]}` : ''
+    let typeQuery = (types.length === 1) ? ` type:${types[0]}` : ''
     let secs = days * 24 * 60 * 60 * 1000
     let timestamp = new Date(new Date() - secs)
     timestamp = timestamp.toISOString().replace(/\.\d{3}\w$/, '')

--- a/lib/validators/stale.js
+++ b/lib/validators/stale.js
@@ -1,4 +1,7 @@
 const { Validator } = require('./validator')
+const constructOutput = require('./options_processor/options/lib/constructOutput')
+
+const MAX_ISSUES = 20 // max issues to retrieve each time.
 
 class Stale extends Validator {
   constructor () {
@@ -9,36 +12,51 @@ class Stale extends Validator {
   }
 
   async validate (context, validationSettings) {
-    let event = `${context.event}`
+    let days = validationSettings.days || 20
+    let typeSetting = validationSettings.type || ['issues', 'pull_request']
+    let types = Array.isArray(typeSetting) &&
+      typeSetting.filter(type => type === 'issues' || type === 'pull_request')
+    types = types || [typeSetting]
 
-    let type = 'issue'
-    if (event === 'pull_request') {
-      type = 'pr'
-    } else return
+    let typeQuery = (types.lenth === 1) ? ` type:${types[0]}` : ''
+    let secs = days * 24 * 60 * 60 * 1000
+    let timestamp = new Date(new Date() - secs)
+    timestamp = timestamp.toISOString().replace(/\.\d{3}\w$/, '')
 
-    await search(context, validationSettings, type)
+    let results = await context.github.search.issues({
+      q: `repo:${context.repo().owner}/${context.repo().repo} is:open updated:<${timestamp}${typeQuery}`,
+      sort: 'updated',
+      order: 'desc',
+      per_page: MAX_ISSUES
+    })
+
+    let items = results.data.items
+    let scheduleResult = {
+      issues: items.filter(item => !item.pull_request),
+      pulls: items.filter(item => item.pull_request)
+    }
+
+    return getResult(scheduleResult, { days: days, types: types }, validationSettings)
   }
 }
 
-const search = async (context, config, type = 'issue') => {
-  const MAX_ISSUES = 20 // max issues to retrieve each time.
+const getResult = (scheduleResult, input, settings) => {
+  let isPass = scheduleResult.issues.length > 0 &&
+    scheduleResult.issues.length > 0
+  let name = 'stale'
+  let status = isPass ? 'pass' : 'fail'
 
-  let secs = config.days * 24 * 60 * 60 * 1000
-  let timestamp = new Date(new Date() - secs)
-  timestamp = timestamp.toISOString().replace(/\.\d{3}\w$/, '')
-
-  let results = await context.github.search.issues({
-    q: `repo:${context.repo().owner}/${context.repo().repo} is:open updated:<${timestamp} type:${type}`,
-    sort: 'updated',
-    order: 'desc',
-    per_page: MAX_ISSUES
-  })
-
-  results.data.items.forEach(issue => {
-    context.github.issues.createComment(
-      context.repo({number: issue.number, body: config.message})
-    )
-  })
+  return {
+    status: status,
+    name: name,
+    validations: constructOutput(
+      name,
+      status,
+      input,
+      settings
+    ),
+    schedule: scheduleResult
+  }
 }
 
 module.exports = Stale


### PR DESCRIPTION
### Goal
Make `stale` work in flex. 

### Changes
- Update comment to execute based on results of validators. Look for schedule results and comment appropriately.
- Update v1 transformer to output correct format for schedule.repository event.
- Update `Stale` validator to focus only on finding stale issues and/or pr -- it shouldn't be creating comments in the new flex.
- Update all relevant unit tests 