### PR TITLE
fix approvals and no_empty enabled option

### DIFF
--- a/lib/validators/options_processor/options/no_empty.js
+++ b/lib/validators/options_processor/options/no_empty.js
@@ -7,8 +7,15 @@ class NoEmpty {
 
     const enabled = filter['enabled']
     let description = filter['message']
-    if (!enabled) {
+    if (!enabled && enabled !== false) {
       throw new Error(ENABLED_NOT_FOUND_ERROR)
+    }
+
+    if (enabled === false) {
+      return {
+        status: 'pass',
+        description: 'No_empty option is not enabled, as such this check did not run'
+      }
     }
 
     let isMergeable


### PR DESCRIPTION
Goal
---
- Fix approval option always running `required` sub-option
- if no_empty.enabled is false, display a proper message instead of throwing errors