### PR TITLE
doc: fixes no_empty suboption for description examples.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,12 +2,12 @@ version: 2 # use CircleCI 2.0
 jobs: # a collection of steps
   build: # runs not using Workflows must have a `build` job as entry point
     docker: # run the steps with Docker
-      - image: circleci/node:7.7.0 # ...with this image as the primary container; this is where all `steps` will run
+      - image: circleci/node:8.8.1 # ...with this image as the primary container; this is where all `steps` will run
     steps: # a collection of executable commands
       - checkout # special step to check out source code to working directory
-      - run:
-          name: update-npm
-          command: 'sudo npm install -g npm@latest'
+      # - run:
+      #     name: update-npm
+      #     command: 'sudo npm install -g npm@latest'
       - restore_cache: # special step to restore the dependency cache
           # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
           key: dependency-cache-{{ checksum "package.json" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,33 @@
+version: 2 # use CircleCI 2.0
+jobs: # a collection of steps
+  build: # runs not using Workflows must have a `build` job as entry point
+    docker: # run the steps with Docker
+      - image: circleci/node:7.7.0 # ...with this image as the primary container; this is where all `steps` will run
+    steps: # a collection of executable commands
+      - checkout # special step to check out source code to working directory
+      - run:
+          name: update-npm
+          command: 'sudo npm install -g npm@latest'
+      - restore_cache: # special step to restore the dependency cache
+          # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
+          key: dependency-cache-{{ checksum "package.json" }}
+      - run:
+          name: install-npm
+          command: npm install
+      - save_cache: # special step to save the dependency cache
+          key: dependency-cache-{{ checksum "package.json" }}
+          paths:
+            - ./node_modules
+      - run: # run tests
+          name: test
+          command: npm test
+      - store_artifacts: # special step to save test results as as artifact
+          # Upload test summary for display in Artifacts: https://circleci.com/docs/2.0/artifacts/
+          path: test-results.xml
+          prefix: tests
+      - store_artifacts: # for display in Artifacts: https://circleci.com/docs/2.0/artifacts/
+          path: coverage
+          prefix: coverage
+      - store_test_results: # for display in Test Summary: https://circleci.com/docs/2.0/collect-test-data/
+          path: test-results.xml
+      # See https://circleci.com/docs/2.0/deployment-integrations/ for deploy examples

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,0 @@
-machine:
-  node:
-    version: 7.7.0

--- a/docs/README.md
+++ b/docs/README.md
@@ -288,7 +288,7 @@ By default if the configuration file does not exist, the following is the defaul
       label: 'work in progress|do not merge|experimental|proof of concept'
       title: 'wip|dnm|exp|poc'
       description:
-        no-empty: true
+        no_empty: true
 ```
 The configuration file follows a certain format. It is in the general following structure:
 
@@ -335,7 +335,7 @@ A list of `advanced_option` for an advanced configuration file are as follows:
 - max
    - count
    - message
-- no-empty
+- no_empty
    - enabled
    - message
 - required


### PR DESCRIPTION
## Context
The `no_empty` suboption for `description` was documented wrongly with a dash instead of underscore.