### PR TITLE
fix no empty description

### DIFF
--- a/__tests__/configuration/transformers/v1Config.test.js
+++ b/__tests__/configuration/transformers/v1Config.test.js
@@ -5,10 +5,11 @@ describe('Tests for description no empty scenarios transformations', () => {
   const verify = (config) => {
     let res = v1Config.transform(yaml.safeLoad(config))
     let dv = res.mergeable[0].validate[0]
+
     expect(res.mergeable[0].when).toBeDefined()
     expect(dv.do).toBe('description')
     expect(dv.no_empty).toBeDefined()
-    expect(dv.no_empty.enabled).toBeTruthy()
+    expect(dv.no_empty.enabled).toBe(true)
   }
 
   test('no_empty using simple config ', () => {

--- a/__tests__/validators/options_processor/options/no_empty.test.js
+++ b/__tests__/validators/options_processor/options/no_empty.test.js
@@ -14,26 +14,24 @@ const validatorContext = {
     'no_empty',
     'required']
 }
-test('return pass if input meets the criteria', async () => {
-  const rule = {no_empty: {enabled: true}}
-  let input = 'NOT EMPTY'
-  let res = noEmpty.process(validatorContext, input, rule)
-  expect(res.status).toBe('pass')
 
-  input = ['']
-  res = noEmpty.process(validatorContext, input, rule)
-  expect(res.status).toBe('pass')
+const verify = (enabled, input, inputArr, result) => {
+  const rule = {no_empty: {enabled: enabled}}
+  let res = noEmpty.process(validatorContext, input, rule)
+  expect(res.status).toBe(result)
+
+  res = noEmpty.process(validatorContext, inputArr, rule)
+  expect(res.status).toBe(result)
+}
+
+test('return pass if input meets the criteria', () => {
+  verify(true, 'NOT EMPTY', [''], 'pass')
+  verify(false, 'NOT EMPTY', [''], 'pass')
 })
 
-test('return fail if input does not meet the criteria', async () => {
-  const rule = {no_empty: {enabled: true}}
-  let input = ''
-  let res = noEmpty.process(validatorContext, input, rule)
-  expect(res.status).toBe('fail')
-
-  input = []
-  res = noEmpty.process(validatorContext, input, rule)
-  expect(res.status).toBe('fail')
+test('return fail if input does not meet the criteria', () => {
+  verify(true, '', [], 'fail')
+  verify(false, '', [''], 'pass')
 })
 
 test('return error if inputs are not in expected format', async () => {

--- a/lib/configuration/transformers/v1Config.js
+++ b/lib/configuration/transformers/v1Config.js
@@ -86,13 +86,15 @@ const processValidators = (event, config, options) => {
     }
 
     if (validator === 'description' &&
-      (typeof value.no_empty !== 'object' ||
-      typeof value['no-empty'] !== 'object')
+      (typeof value.no_empty === 'boolean' ||
+      value['no-empty'] !== undefined)
     ) {
-      return Object.assign(value, {
+      let enabled = (typeof value.no_empty === 'boolean')
+        ? value.no_empty : value['no-empty'].enabled || value['no-empty']
+      return {
         do: 'description',
-        no_empty: { enabled: value.no_empty || value['no-empty'] }
-      })
+        no_empty: { enabled: enabled }
+      }
     }
 
     return Object.assign(value, {'do': validator})

--- a/lib/validators/options_processor/options/no_empty.js
+++ b/lib/validators/options_processor/options/no_empty.js
@@ -7,7 +7,7 @@ class NoEmpty {
 
     const enabled = filter['enabled']
     let description = filter['message']
-    if (!enabled) {
+    if (enabled === undefined) {
       throw new Error(ENABLED_NOT_FOUND_ERROR)
     }
 


### PR DESCRIPTION
### Context
- When `no_empty` enabled is `false` the validator thinks the enabled is not specified.
- output of transform for `no_empty` and `no-empty` simple config was wrong.

### Changes
- harden transform tests for `no_empty` and `no-empty` sub-options and fix the transform
- fix the validator so that it does not throw error when enabled is false for no_empty.

