### PR TITLE
display the proper project names

### DIFF
--- a/lib/validators/project.js
+++ b/lib/validators/project.js
@@ -52,7 +52,6 @@ class Project extends Validator {
 
       isMergeable = issuesPrCloses.some(issue => idsFromCards.includes(issue))
     }
-    console.log('projects', projects)
     return consolidateResult([constructOutput(validatorContext, projects.map(proj => proj.name), validationSettings, {
       status: isMergeable ? 'pass' : 'fail',
       description: isMergeable ? DEFUALT_SUCCESS_MESSAGE : description

--- a/lib/validators/project.js
+++ b/lib/validators/project.js
@@ -52,7 +52,8 @@ class Project extends Validator {
 
       isMergeable = issuesPrCloses.some(issue => idsFromCards.includes(issue))
     }
-    return consolidateResult([constructOutput(validatorContext, projects, validationSettings, {
+    console.log('projects', projects)
+    return consolidateResult([constructOutput(validatorContext, projects.map(proj => proj.name), validationSettings, {
       status: isMergeable ? 'pass' : 'fail',
       description: isMergeable ? DEFUALT_SUCCESS_MESSAGE : description
     })], validatorContext)


### PR DESCRIPTION
Context
---
Currently the input for project validators is `[Object]` 