### PR TITLE
fix(configuration): Bad YML with no user feedback

### DIFF
--- a/__tests__/actions/checks.test.js
+++ b/__tests__/actions/checks.test.js
@@ -1,6 +1,13 @@
 const Checks = require('../../lib/actions/checks')
 const Helper = require('../../__fixtures__/helper')
 
+test('run', async () => {
+  const checks = new Checks()
+  const context = createMockContext()
+  await checks.run({ context, payload: {} })
+  expect(context.github.checks.create.mock.calls.length).toBe(1)
+})
+
 test('check that checks created when doPostAction is called with proper parameter', async () => {
   const checks = new Checks()
   const context = createMockContext()

--- a/__tests__/configuration/configuration.test.js
+++ b/__tests__/configuration/configuration.test.js
@@ -29,7 +29,7 @@ describe('Loading bad configuration', () => {
     mergeable:
     `)
     expect(config.errors.size).toBe(1)
-    expect(config.errors.has(Configuration.ERROR_CODES.WRONG_VERSION)).toBe(true)
+    expect(config.errors.has(Configuration.ERROR_CODES.UNKOWN_VERSION)).toBe(true)
   })
 
   test('missing mergeable node', () => {
@@ -164,6 +164,7 @@ describe('with version 2', () => {
     let config = new Configuration()
     expect(config.settings[0].when).toBeDefined()
     expect(config.settings[0].validate).toBeDefined()
+    expect(config.hasErrors()).toBe(false)
   })
 })
 

--- a/__tests__/flex.test.js
+++ b/__tests__/flex.test.js
@@ -6,6 +6,29 @@ describe('#executor', () => {
     process.env.MERGEABLE_VERSION = 'flex'
   })
 
+  test('Bad YML', async () => {
+    let context = Helper.mockContext('title')
+    Helper.mockConfigWithContext(context, `
+      version: 2
+      mergeable:
+    when: pull_request.*
+    `)
+
+    context.event = 'pull_request'
+    context.payload.action = 'opened'
+    context.github.checks.create = jest.fn()
+    context.github.checks.update = jest.fn()
+
+    await executor(context, { validators: new Map(), actions: new Map() })
+    expect(context.github.checks.update.mock.calls.length).toBe(0)
+    expect(context.github.checks.create.mock.calls.length).toBe(1)
+
+    const theCall = context.github.checks.create.mock.calls[0][0]
+    expect(theCall.status).toBe('completed')
+    expect(theCall.conclusion).toBe('cancelled')
+    console.log(context.github.checks.create.mock.calls[0][0])
+  })
+
   test('One When', async () => {
     let context = Helper.mockContext('title')
     Helper.mockConfigWithContext(context, `

--- a/__tests__/flex.test.js
+++ b/__tests__/flex.test.js
@@ -26,7 +26,6 @@ describe('#executor', () => {
     const theCall = context.github.checks.create.mock.calls[0][0]
     expect(theCall.status).toBe('completed')
     expect(theCall.conclusion).toBe('cancelled')
-    console.log(context.github.checks.create.mock.calls[0][0])
   })
 
   test('One When', async () => {

--- a/lib/actions/action.js
+++ b/lib/actions/action.js
@@ -7,6 +7,9 @@ class Action extends EventAware {
   async afterValidate () {
     throw new Error('class extending Action must implement afterValidate function')
   }
+
+  // intentionally do nothing. To be implemented by the inheriting Action classes.
+  async run ({ context, settings, payload }) {}
 }
 
 module.exports = {

--- a/lib/actions/checks.js
+++ b/lib/actions/checks.js
@@ -1,32 +1,26 @@
 const { Action } = require('./action')
 const populateTemplate = require('./handlebars/populateTemplate')
+const _ = require('lodash')
 
-const createChecks = async (context, name, status, output) => {
-  let headBranch
-  let headSha
+const createChecks = async (context, payload) => {
+  let params = _.cloneDeep(payload)
+  params.name = 'Mergeable'
 
-  if (!output) {
-    output = {
-      title: 'Mergeable Tests running',
-      summary: `Please be patient, we'll get you the result as soon as possible`
-    }
-  }
-
+  // Note: octokit (wrapped by probot) requires head_branch.
+  // Contradicting API docs that only requires head_sha
+  // --> https://developer.github.com/v3/checks/runs/#create-a-check-run
   if (context.payload.checksuite) {
-    // being called by check_run
-    headBranch = context.payload.checksuite.head_branch
-    headSha = context.payload.checksuite.head_sha
+    params.head_branch = context.payload.checksuite.head_branch
+    params.head_sha = context.payload.checksuite.head_sha
   } else {
-    headBranch = context.payload.pull_request.head.ref
-    headSha = context.payload.pull_request.head.sha
+    params.head_branch = context.payload.pull_request.head.ref
+    params.head_sha = context.payload.pull_request.head.sha
   }
-  status = !status ? 'in_progress' : status
 
   let log = context.log.child({name: 'mergeable'})
-  let params = createParams({context, headBranch, headSha, name, status, output})
-  log.debug(`Creating Check for ${context.payload.repository.full_name} - status=${status}`)
+  log.debug(`Creating Check for ${context.payload.repository.full_name} - status=${params.status}`)
   log.debug(params)
-  return context.github.checks.create(params)
+  return context.github.checks.create(context.repo(params))
 }
 
 const updateChecks = async (context, id, name, status, conclusion, output) => {
@@ -45,17 +39,6 @@ const updateChecks = async (context, id, name, status, conclusion, output) => {
   log.debug(`Updating Check for ${context.payload.repository.full_name} - status=${status}`)
   log.debug(params)
   await context.github.checks.update(params)
-}
-
-const createParams = ({context, headBranch, headSha, name, status, output}) => {
-  return context.repo({
-    name: name,
-    status: status,
-    output: output,
-    head_branch: headBranch,
-    head_sha: headSha,
-    started_at: new Date()
-  })
 }
 
 const updateParams = ({context, id, name, status, output, conclusion}) => {
@@ -88,8 +71,15 @@ class Checks extends Action {
     ]
   }
 
-  async beforeValidate ({context}) {
-    this.checkRunResult = await createChecks(context, 'Mergeable')
+  async beforeValidate ({ context }) {
+    this.checkRunResult = await createChecks(context, {
+      status: 'in_progress',
+      output: {
+        title: 'Mergeable is running.',
+        summary: `Please be patient. We'll get you the results as soon as possible.`
+      },
+      started_at: new Date()
+    })
   }
 
   populatePayloadWithResult (settings, results) {
@@ -99,6 +89,10 @@ class Checks extends Action {
     })
 
     return output
+  }
+
+  async run ({ context, settings, payload }) {
+    await createChecks(context, payload)
   }
 
   async afterValidate (context, settings, results) {

--- a/lib/configuration/configuration.js
+++ b/lib/configuration/configuration.js
@@ -3,6 +3,8 @@ const consts = require('./lib/consts')
 
 class Configuration {
   constructor (settings) {
+    this.errors = new Map()
+    this.warnings = new Map()
     if (settings === undefined) {
       this.settings = [{
         when: 'pull_request.*',
@@ -12,26 +14,21 @@ class Configuration {
         error: consts.DEFAULT_PR_ERROR
       }]
     } else {
-      this.settings = yaml.safeLoad(settings)
+      try {
+        this.settings = yaml.safeLoad(settings)
+      } catch (e) {
+        this.errors.set(ERROR_CODES.BAD_YML, e)
+        return // intentionally return since there's not much more we can do.
+      }
+
+      this.validate()
+      if (this.errors.size > 0) return
+
       const version = this.checkConfigVersion()
+      if (version === 1) this.loadDefaults()
 
-      if (typeof version !== 'number') {
-        throw new Error(Configuration.UNKNOWN_VERSION_ERROR)
-      }
-
-      if (version === 1) {
-        this.validate()
-        this.loadDefaults()
-      }
-
-      if (version > 0) {
-        this.settings = (require(`./transformers/v${version}Config`).transform(this.settings))
-        if (!!this.settings.mergeable) { // eslint-disable-line
-          this.settings = this.settings.mergeable
-        } else {
-          throw new Error('mergeable object not found in the configuration')
-        }
-      }
+      this.settings = (require(`./transformers/v${version}Config`).transform(this.settings))
+      this.settings = this.settings.mergeable
     }
   }
 
@@ -91,7 +88,16 @@ class Configuration {
 
   validate () {
     if (this.settings.mergeable === undefined) {
-      throw new Error(Configuration.ERROR_INVALID_YML)
+      this.errors.set(
+        ERROR_CODES.MISSING_MERGEABLE_NODE,
+        ERROR_MESSAGES.MISSING_MERGEABLE_NODE
+      )
+    }
+    if (this.settings.version && typeof this.settings.version !== 'number') {
+      this.errors.set(
+        ERROR_CODES.UNKNOWN_VERSION,
+        ERROR_MESSAGES.UNKNOWN_VERSION
+      )
     }
   }
 
@@ -140,18 +146,21 @@ class Configuration {
   static instanceWithContext (context) {
     return Configuration.fetchConfigFile(context).then(res => {
       let content = Buffer.from(res.data.content, 'base64').toString()
-
       return new Configuration(content)
     }).catch(error => {
-      if (error.code === 404) return new Configuration()
-      else throw error
+      let config = new Configuration()
+      console.log(config)
+      if (error.code === 404) {
+        config.warnings.set(WARNING_CODES.CONFIG_NOT_FOUND, WARNING_CONFIG_NOT_FOUND)
+      } else {
+        config.errors.set(ERROR_CODES.GITHUB_API_ERROR, error)
+      }
+      return config
     })
   }
 }
 
 Configuration.FILE_NAME = '.github/mergeable.yml'
-Configuration.ERROR_INVALID_YML = 'Invalid mergeable YML file format. Root mergeable node is missing.'
-Configuration.UNKNOWN_VERSION_ERROR = 'Invalid version provided! please check README to check all the supported Versions!'
 Configuration.DEFAULTS = {
   label: 'work in progress|do not merge|experimental|proof of concept',
   title: 'wip|dnm|exp|poc',
@@ -159,5 +168,24 @@ Configuration.DEFAULTS = {
     message: 'There haven\'t been much activity here. This is stale. Is it still relevant? This is a friendly reminder to please resolve it. :-)'
   }
 }
+const ERROR_CODES = {
+  BAD_YML: 10,
+  MISSING_MERGEABLE_NODE: 20,
+  UNKOWN_VERSION: 30,
+  CONFIG_NOT_FOUND: 40,
+  GITHUB_API_ERROR: 50
+}
+Configuration.ERROR_CODES = ERROR_CODES
+const ERROR_MESSAGES = {
+  MISSING_MERGEABLE_NODE: 'Invalid mergeable YML file format. Root mergeable node is missing.',
+  UNKNOWN_VERSION: 'Invalid version provided. Please check the [README](https://github.com/jusx/mergeable) for more details.'
+}
+
+const WARNING_CODES = {
+  CONFIG_NOT_FOUND: 10
+}
+Configuration.WARNING_CODES = WARNING_CODES
+
+const WARNING_CONFIG_NOT_FOUND = `Configuration file was not found in \`${Configuration.FILE_NAME}\``
 
 module.exports = Configuration

--- a/lib/configuration/configuration.js
+++ b/lib/configuration/configuration.js
@@ -33,13 +33,8 @@ class Configuration {
   }
 
   checkConfigVersion () {
-    if (!this.isFlexVersion()) {
-      return 0
-    }
-
-    if (!this.settings.version) {
-      return 1
-    }
+    if (!this.isFlexVersion()) return 0
+    if (!this.settings.version) return 1
     return (this.settings.version)
   }
 

--- a/lib/configuration/configuration.js
+++ b/lib/configuration/configuration.js
@@ -17,7 +17,7 @@ class Configuration {
       try {
         this.settings = yaml.safeLoad(settings)
       } catch (e) {
-        this.errors.set(ERROR_CODES.BAD_YML, e)
+        this.errors.set(ERROR_CODES.BAD_YML, `Invalid YML format > ${e.message}`)
         return // intentionally return since there's not much more we can do.
       }
 
@@ -30,6 +30,10 @@ class Configuration {
       this.settings = (require(`./transformers/v${version}Config`).transform(this.settings))
       this.settings = this.settings.mergeable
     }
+  }
+
+  hasErrors () {
+    return (this.errors.size > 0)
   }
 
   checkConfigVersion () {
@@ -90,7 +94,7 @@ class Configuration {
     }
     if (this.settings.version && typeof this.settings.version !== 'number') {
       this.errors.set(
-        ERROR_CODES.UNKNOWN_VERSION,
+        ERROR_CODES.UNKOWN_VERSION,
         ERROR_MESSAGES.UNKNOWN_VERSION
       )
     }
@@ -172,8 +176,8 @@ const ERROR_CODES = {
 }
 Configuration.ERROR_CODES = ERROR_CODES
 const ERROR_MESSAGES = {
-  MISSING_MERGEABLE_NODE: 'Invalid mergeable YML file format. Root mergeable node is missing.',
-  UNKNOWN_VERSION: 'Invalid version provided. Please check the [README](https://github.com/jusx/mergeable) for more details.'
+  MISSING_MERGEABLE_NODE: 'The `mergeable` node is missing.',
+  UNKNOWN_VERSION: 'Invalid `version` found.'
 }
 
 const WARNING_CODES = {

--- a/lib/flex.js
+++ b/lib/flex.js
@@ -1,5 +1,6 @@
 const Configuration = require('./configuration/configuration')
 const extractValidationStats = require('./stats/extractValidationStats')
+const Checks = require('./actions/checks')
 
 // Main logic Processor of mergeable
 const executeMergeable = async (context, registry) => {
@@ -13,6 +14,43 @@ const executeMergeable = async (context, registry) => {
   // first fetch the configuration
   let config = await Configuration.instanceWithContext(context)
 
+  if (config.hasErrors()) {
+    let log = context.log.child({ name: 'mergeable' })
+    let evt = `${context.event}.${context.payload.action}`
+    log.info('Errors found in yml configuration on %s :\n ', evt, config.errors)
+    let checks = new Checks()
+    if (checks.isEventSupported(evt)) {
+      checks.run({
+        context: context,
+        payload: {
+          status: 'completed',
+          conclusion: 'cancelled',
+          output: {
+            title: 'Invalid Configuration',
+            summary: formatErrorSummary(config.errors)
+          },
+          completed_at: new Date()
+        }
+      })
+    }
+  } else {
+    await processWorkflow(context, registry, config)
+  }
+}
+
+const formatErrorSummary = (errors) => {
+  let it = errors.values()
+  let summary = `Errors were found in the configuration (${Configuration.FILE_NAME}):`
+  let message = it.next()
+  while (!message.done) {
+    summary += '\n- ' + message.value
+    message = it.next()
+  }
+  summary += '\n\nSee the [documentation](https://github.com/jusx/mergeable) for details on configuration.'
+  return summary
+}
+
+const processWorkflow = async (context, registry, config) => {
   // go through the settings and register all the validators
   await config.registerValidatorsAndActions(registry)
 


### PR DESCRIPTION
### Context
Currently, when any problem is found with the configuration an error is thrown with no feedback given to the user:

1. A badly formatted YML is encountered
2. Version is invalid
3. `mergeable` node is missing.

The result is that the checks are never completed and the status stays at `queued` and is never `completed`.

fixes #154 

### Changes
- Configuration while loading yml will validate and collect errors instead of throwing.
- Flex executor now creates a check suite if there is invalid configuration with a `cancelled` conclusion so as not to leave the check suite hanging.