### PR TITLE
chore(configuration): Remove needless console.log as it is polluting …

### DIFF
--- a/lib/configuration/configuration.js
+++ b/lib/configuration/configuration.js
@@ -148,7 +148,6 @@ class Configuration {
       return new Configuration(content)
     }).catch(error => {
       let config = new Configuration()
-      console.log(config)
       if (error.code === 404) {
         config.warnings.set(WARNING_CODES.CONFIG_NOT_FOUND, WARNING_CONFIG_NOT_FOUND)
       } else {


### PR DESCRIPTION
The logs are being polluted by console.log of configuration when it is not found. It is not useful.

## Changes
- one line removal of `console.log` in Configuration class.