### PR TITLE
fix(flex): before validate invocation

### DIFF
--- a/lib/flex.js
+++ b/lib/flex.js
@@ -53,6 +53,8 @@ const formatErrorSummary = (errors) => {
 const processWorkflow = async (context, registry, config) => {
   // go through the settings and register all the validators
   config.registerValidatorsAndActions(registry)
+
+  // do pre validation actions
   await processPreActions(context, registry, config)
 
   // process each rule found in configuration

--- a/lib/flex.js
+++ b/lib/flex.js
@@ -52,9 +52,7 @@ const formatErrorSummary = (errors) => {
 
 const processWorkflow = async (context, registry, config) => {
   // go through the settings and register all the validators
-  await config.registerValidatorsAndActions(registry)
-
-  // do pre validation actions
+  config.registerValidatorsAndActions(registry)
   await processPreActions(context, registry, config)
 
   // process each rule found in configuration
@@ -81,9 +79,14 @@ const getValiatorPromises = (context, registry, rule) => {
 // call all action classes' beforeValidate, regardless of whether they are in failure or pass situation
 const processPreActions = async (context, registry, config) => {
   let promises = []
-  registry.actions.forEach(action => {
-    if (action.isEventSupported(`${context.event}.${context.payload.action}`)) {
-      promises.push(action.beforeValidate({ context }))
+
+  config.settings.forEach(rule => {
+    if (isEventInContext(rule.when, context)) {
+      registry.actions.forEach(action => {
+        if (action.isEventSupported(`${context.event}.${context.payload.action}`)) {
+          promises.push(action.beforeValidate({ context }))
+        }
+      })
     }
   })
 


### PR DESCRIPTION
Check if the event triggered is relevant before invoking `beforeValidate` on any `Action`s

fixes #168 

## Changes
- Added unit tests for checking proper before and after validate invocations.
- Added checks for all recipes and it's events before invoking beforeValidate.
