### PR TITLE
fix(approvals): Should not fail when reviewer approved and later comment

### DIFF
--- a/__tests__/validators/options_processor/options/or.test.js
+++ b/__tests__/validators/options_processor/options/or.test.js
@@ -1,7 +1,7 @@
 const or = require('../../../../lib/validators/options_processor/options/or')
 
 const validatorContext = {
-  name: 'label',
+  name: 'OptionName',
   supportedOptions: [
     'and',
     'or',
@@ -14,27 +14,22 @@ const validatorContext = {
     'no_empty',
     'required']
 }
-test('return pass if input begins with the rule', async () => {
-  const rule = {or: [{must_include: {regex: 'A'}}, {must_exclude: {regex: 'B'}}]}
-  let input = ['A']
+test('return pass if input passes one of the OR conditions', async () => {
+  const rule = { or: [
+    { must_include: {regex: 'A'} },
+    { must_exclude: {regex: 'B'} }
+  ]}
+  let input = ['A', 'C']
   let res = or.process(validatorContext, input, rule)
   expect(res.status).toBe('pass')
 })
 
-// test('return fail if input does not begins with the rule', async () => {
-//   const rule = {or: [{must_include: {regex: 'A'}}, {must_exclude: {regex: 'B'}}]}
-//   const input = ['B', 'D']
-//   const res = or.process(validatorContext, input, rule)
-//   expect(res.status).toBe('fail')
-// })
-//
-// test('return error if inputs are not in expected format', async () => {
-//   const rule = {or: {must_include: {regex: 'A'}}}
-//   const input = 'the test'
-//   try {
-//     let config = or.process(validatorContext, input, rule)
-//     expect(config).toBeUndefined()
-//   } catch (e) {
-//     expect(e.message).toBe('Input type invalid, expected array type as input')
-//   }
-// })
+test('return fail if none of the input passes one of the OR conditions', async () => {
+  const rule = { or: [
+    {required: { reviewers: ['user1'] }},
+    {required: { reviewers: ['user2'] }}
+  ]}
+  let input = ['user0', 'user5', 'user3']
+  let res = or.process(validatorContext, input, rule)
+  expect(res.status).toBe('fail')
+})

--- a/lib/validators/approvals.js
+++ b/lib/validators/approvals.js
@@ -48,10 +48,7 @@ class Approvals extends Validator {
       validationSettings = Object.assign({}, validationSettings, {required: { owners: ownerList, reviewers: requiredReviewer }})
     }
 
-    let filteredReviews = filterOutOldReviews(reviews.data)
-    let approvedReviewers = filteredReviews
-      .filter(element => element.state.toLowerCase() === 'approved')
-      .map(review => review.user && review.user.login)
+    let approvedReviewers = findApprovedReviewers(reviews.data)
 
     // if pr creator exists in the list of required reviewers, remove it
     if (requiredReviewer.includes(prCreator)) {
@@ -63,9 +60,20 @@ class Approvals extends Validator {
   }
 }
 
-const filterOutOldReviews = (reviews) => {
-  const ordered = _.orderBy(reviews, ['submitted_at'], ['desc'])
-  return _.uniqBy(ordered, 'user.login')
+const findApprovedReviewers = (reviews) => {
+  // filter out review submitted comments because it does not nullify an approved state.
+  // Other possible states are PENDING and REQUEST_CHANGES. At those states the user has not approved the PR.
+  // See https://developer.github.com/v3/pulls/reviews/#list-reviews-on-a-pull-request
+  const relevantReviews = reviews.filter(element => element.state.toLowerCase() !== 'comment')
+
+  // order it by date of submission.
+  const ordered = _.orderBy(relevantReviews, ['submitted_at'], ['desc'])
+  const uniqueByUser = _.uniqBy(ordered, 'user.login')
+
+  // approved reviewers are ones that are approved and not nullified by other submissions later.
+  return uniqueByUser
+    .filter(element => element.state.toLowerCase() === 'approved')
+    .map(review => review.user && review.user.login)
 }
 
 module.exports = Approvals


### PR DESCRIPTION
fixes #174 

## Changes
- Added more tests to `OR` operands to improve coverage.
- Fix the logic to find approvers in the PR reviews. It should not take into account the comment after an approval is made. Since it does not approve or reject a PR we filter it out all together.
- Add test to cover all edge cases for review states.
