### PR TITLE
chore(codecov): Only collect code coverage during the test-coverage e…

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "probot run ./index.js",
     "test": "jest && standard",
     "test-watch": "jest --watch",
-    "test-coverage": "npm test && codecov",
+    "test-coverage": "standard && jest --collectCoverage && codecov",
     "lint": "standard --fix"
   },
   "dependencies": {
@@ -40,7 +40,6 @@
   },
   "jest": {
     "coverageDirectory": "./coverage/",
-    "collectCoverage": true,
     "collectCoverageFrom": ["lib/**/*.js"]
   }
 }


### PR DESCRIPTION
## Goal
When in dev and running `npm test-watch` we don't want jest to run code coverage. That should only run during CI or when we explicitly want it.

## Changes
- Remove collectCoverage setting from global and moved it to CLI as needed.