### PR TITLE
fix(approvals): finding approved reviewers should properly ignore comments

### DIFF
--- a/__tests__/validators/approvals.test.js
+++ b/__tests__/validators/approvals.test.js
@@ -144,12 +144,12 @@ test('validate correctly when one required user approved but followed up with co
   const reviewList = [
     {
       user: { login: 'userA' },
-      state: 'COMMENT',
+      state: 'COMMENTED',
       submitted_at: Date.now() - 5000
     },
     {
       user: { login: 'userB' },
-      state: 'COMMENT',
+      state: 'COMMENTED',
       submitted_at: Date.now() - 4000
     },
     {
@@ -159,7 +159,7 @@ test('validate correctly when one required user approved but followed up with co
     },
     {
       user: { login: 'userB' },
-      state: 'COMMENT',
+      state: 'COMMENTED',
       submitted_at: Date.now() - 2000
     },
     {
@@ -169,12 +169,12 @@ test('validate correctly when one required user approved but followed up with co
     },
     {
       user: { login: 'userA' },
-      state: 'COMMENT',
+      state: 'COMMENTED',
       submitted_at: Date.now()
     },
     {
       user: { login: 'userC' },
-      state: 'COMMENT',
+      state: 'COMMENTED',
       submitted_at: Date.now()
     }
   ]
@@ -194,12 +194,12 @@ test('validate correctly when one required user approved but followed up with RE
   const reviewList = [
     {
       user: { login: 'userA' },
-      state: 'COMMENT',
+      state: 'COMMENTED',
       submitted_at: Date.now() - 5000
     },
     {
       user: { login: 'userB' },
-      state: 'COMMENT',
+      state: 'COMMENTED',
       submitted_at: Date.now() - 4000
     },
     {
@@ -209,7 +209,7 @@ test('validate correctly when one required user approved but followed up with RE
     },
     {
       user: { login: 'userB' },
-      state: 'COMMENT',
+      state: 'COMMENTED',
       submitted_at: Date.now() - 2000
     },
     {
@@ -219,7 +219,7 @@ test('validate correctly when one required user approved but followed up with RE
     },
     {
       user: { login: 'userA' },
-      state: 'REQUEST_CHANGES',
+      state: 'CHANGES_REQUESTED',
       submitted_at: Date.now() - 500
     },
     {

--- a/lib/validators/approvals.js
+++ b/lib/validators/approvals.js
@@ -64,9 +64,11 @@ const findApprovedReviewers = (reviews) => {
   // filter out review submitted comments because it does not nullify an approved state.
   // Other possible states are PENDING and REQUEST_CHANGES. At those states the user has not approved the PR.
   // See https://developer.github.com/v3/pulls/reviews/#list-reviews-on-a-pull-request
-  const relevantReviews = reviews.filter(element => element.state.toLowerCase() !== 'comment')
+  // While submitting a review requires the states be PENDING, REQUEST_CHANGES, COMMENT and APPROVE
+  // The payload actually returns the state in past tense: i.e. APPROVED, COMMENTED
+  const relevantReviews = reviews.filter(element => element.state.toLowerCase() !== 'commented')
 
-  // order it by date of submission.
+  // order it by date of submission. The docs says the order is chronological but we do this anyway to be sure.
   const ordered = _.orderBy(relevantReviews, ['submitted_at'], ['desc'])
   const uniqueByUser = _.uniqBy(ordered, 'user.login')
 


### PR DESCRIPTION
Should take care of #174 

## Changes
- The GH API payload returns the states in past tense, we coded as a verb (action) as documented for submission. Changed to evaluating past tense of the verb for `COMMENT`