### PR TITLE
feat(dependent): Add ability to only validate files when a specific file is in the change-set

### DIFF
--- a/__tests__/validators/dependent.test.js
+++ b/__tests__/validators/dependent.test.js
@@ -1,6 +1,58 @@
 const Helper = require('../../__fixtures__/helper')
 const Dependent = require('../../lib/validators/dependent')
 
+describe('dependent files with modified', () => {
+  test('changed file exists and files found', async () => {
+    const dependent = new Dependent()
+    const settings = {
+      do: 'dependent',
+      changed: {
+        file: 'package.json',
+        files: ['package-lock.json', 'yarn.lock']
+      }
+
+    }
+
+    let validation = await dependent.validate(createMockContext(['package-lock.json', 'yarn.lock', 'package.json', 'a.js']), settings)
+    expect(validation.status).toBe('pass')
+
+    // test with only requiring one dependent file.
+    settings.changed.files = ['package-lock.json']
+    validation = await dependent.validate(createMockContext(['package-lock.json', 'yarn.lock', 'package.json', 'a.js']), settings)
+    expect(validation.status).toBe('pass')
+  })
+
+  test('changed file exist and file(s) not found', async () => {
+    const dependent = new Dependent()
+    const settings = {
+      do: 'dependent',
+      changed: {
+        file: 'package.json',
+        files: ['package-lock.json']
+      }
+
+    }
+
+    let validation = await dependent.validate(createMockContext(['package.json', 'a.js', 'b.js']), settings)
+    expect(validation.status).toBe('fail')
+  })
+
+  test('modified does not exist and file(s) not found', async () => {
+    const dependent = new Dependent()
+    const settings = {
+      do: 'dependent',
+      changed: {
+        file: 'package.json',
+        files: ['package-lock.json']
+      }
+
+    }
+
+    let validation = await dependent.validate(createMockContext([]), settings)
+    expect(validation.status).toBe('pass')
+  })
+})
+
 test('that mergeable is true if none of the dependent file is modified', async () => {
   const dependent = new Dependent()
   const settings = {
@@ -19,7 +71,7 @@ test('that mergeable is true if all of the dependent file is modified', async ()
     files: ['package.json', 'yarn.lock']
   }
 
-  let validation = await dependent.validate(createMockContext(['package.json', 'yarn.lock']), settings)
+  let validation = await dependent.validate(createMockContext(['package.json', 'yarn.lock', 'a.js']), settings)
   expect(validation.status).toBe('pass')
 })
 
@@ -61,7 +113,7 @@ test('that mergeable is false when only some of the dependent files are modified
     files: ['package.json', 'yarn.lock']
   }
 
-  let validation = await dependent.validate(createMockContext(['package.json']), settings)
+  let validation = await dependent.validate(createMockContext(['package.json', 'a.js', 'b.js']), settings)
   expect(validation.status).toBe('fail')
 })
 

--- a/lib/validators/dependent.js
+++ b/lib/validators/dependent.js
@@ -26,8 +26,8 @@ class Dependent extends Validator {
   async validate (context, validationSettings) {
     let dependentFiles = validationSettings.files
 
-    const FILES_NOT_FOUND_ERROR = `Failed to run the test because 'files' is not provided for 'dependent' option. Please check README for more information about configuration`
-    const DEFUALT_SUCCESS_MESSAGE = 'All the Dependents files are represent'
+    const FILES_NOT_FOUND_ERROR = `Failed to validate because the 'files' or 'changed' option is missing. Please check the documentation.`
+    const DEFUALT_SUCCESS_MESSAGE = 'All the Dependents files are present!'
 
     // fetch the file list
     let result = await context.github.pullRequests.getFiles(context.repo({number: this.getPayload(context).number}))
@@ -36,16 +36,23 @@ class Dependent extends Validator {
       .map(file => file.filename)
     const validatorContext = {name: 'Dependent'}
 
-    if (!dependentFiles) {
+    if (!dependentFiles && !validationSettings.changed) {
       return consolidateResult([constructError('Dependent', modifiedFiles, validationSettings, FILES_NOT_FOUND_ERROR)], validatorContext)
     }
+
+    // when changed option is specified, the validator uses this instead as it's files to validate
+    if (validationSettings.changed) {
+      dependentFiles = modifiedFiles.includes(validationSettings.changed.file)
+        ? [validationSettings.changed.file].concat(validationSettings.changed.files)
+        : []
+    }
+
     const fileDiff = _.difference(dependentFiles, modifiedFiles)
 
     let description = validationSettings.message ||
       `One or more files (${fileDiff.join(', ')}) are missing from your pull request because they are dependent on the following: ${_.difference(dependentFiles, fileDiff)}`
 
     const isMergeable = dependentFiles.length === fileDiff.length || fileDiff.length === 0
-
     const output = [constructOutput('Dependent', modifiedFiles, validationSettings, {
       status: isMergeable ? 'pass' : 'fail',
       description: isMergeable ? DEFUALT_SUCCESS_MESSAGE : description


### PR DESCRIPTION
## Goal
In most cases we only want dependent files validated when a certain file is added/modified:

1. When `package.json` has changed, `package-lock.json` should exist but if we only have `package-lock.json` updated, `package.json` does not need to be updated. This happens when running `
npm install` where packages have not changed but minor versions have been installed. (.i.e. using ~ or ^ like so `~1.2.0`)

2. When `Gemfile` has been changed, we want to validate `Gemfile.lock` -- however one can run the bundler to update the gem versions without updating the `Gemfile`. (i.e. pessimistic restriction like so: '~> 3.1.1' is used and bundler is run).

New settings allows for:
```yml
- do: dependent
   changed:
      file: package.json
      files: ['package-lock.json', 'yarn.lock']
```

Where `changed.files` are validated to exist in the PR only when package.json has been added/modified.

## Changes
- update tests for `files` options to cover edge cases -- specify additional files in the modified file change-set.
- Use the files specified in `changed` option when it is specified instead. Validation will only run if changed.file is in the change-set of the PR.
- Validator should only error when both `changed` and `files` are missing as options. The existence of either one is acceptable.

## Note
- Once this is merged, the docs will be updated. Secondly this validator currently does not support OR or AND. That will be added at a later time. 