### PR TITLE
fix: Remove leftover comment from validator.js

### DIFF
--- a/lib/validators/validator.js
+++ b/lib/validators/validator.js
@@ -24,14 +24,6 @@ class Validator extends EventAware {
     throw new Error('Class extending validator must implement validate function')
   }
 
-  /**
-   * @param eventName
-   *  An event name to be evaluated for support. The name is as in the GitHub
-   *  webhook format of issues.opened, pull_request.opened, etc
-   *
-   * @return boolean true if the validator supports the event. i.e. issues.opened
-   */
-
   processOptions (vSettings, value, supportedOptions) {
     return options.process({
       name: vSettings.do,


### PR DESCRIPTION
This comment seems to be leftover from a previous version of this file
(2da0093e11bf40ca2803cc1eb4997581c87c8665).

The function it refers to now exists in eventAware.js along with the
same comment.