### PR TITLE
fix: Remove unecessary condition from no_empty.js

### DIFF
--- a/lib/validators/options_processor/options/no_empty.js
+++ b/lib/validators/options_processor/options/no_empty.js
@@ -24,7 +24,7 @@ class NoEmpty {
     if (!description) description = `The ${validatorContext.name} can't be empty`
 
     if (typeof input === 'string') {
-      isMergeable = !(enabled && input.trim().length === 0)
+      isMergeable = input.trim().length !== 0
     } else if (Array.isArray(input)) {
       isMergeable = input.length !== 0
     } else {


### PR DESCRIPTION
At some point, logic was added in this file that checks whether `enabled
=== false`, and if so returns early with a warning.

As such, the validation logic that happens below this doesn't need to check
this condition again.