### PR TITLE
feat: Add PR size validator

### DIFF
--- a/__fixtures__/helper.js
+++ b/__fixtures__/helper.js
@@ -82,7 +82,17 @@ module.exports = {
         pullRequests: {
           getFiles: () => {
             if (_.isString(options.files && options.files[0])) {
-              return { data: options.files.map(file => ({filename: file, status: 'modified'})) }
+              return {
+                data: options.files.map(
+                  file => ({
+                    filename: file.filename || file,
+                    status: file.status || 'modified',
+                    additions: file.additions || 0,
+                    deletions: file.deletions || 0,
+                    changes: file.changes || 0
+                  })
+                )
+              }
             } else {
               return { data: options.files && options.files }
             }

--- a/__tests__/validators/options_processor/options/max.test.js
+++ b/__tests__/validators/options_processor/options/max.test.js
@@ -15,27 +15,72 @@ const validatorContext = {
     'required']
 }
 
-test('return pass if input meets the criteria', async () => {
-  const rule = {max: {count: 3}}
-  let input = ['A', 'B', 'C']
-  let res = max.process(validatorContext, input, rule)
-  expect(res.status).toBe('pass')
+describe('max option applied to arrays', () => {
+  test('return pass if input meets the criteria', async () => {
+    const rule = {max: {count: 3}}
+    let input = ['A', 'B']
+    let res = max.process(validatorContext, input, rule)
+    expect(res.status).toBe('pass')
+  })
+
+  test('return pass if input exactly meets the criteria', async () => {
+    const rule = {max: {count: 3}}
+    let input = ['A', 'B', 'C']
+    let res = max.process(validatorContext, input, rule)
+    expect(res.status).toBe('pass')
+  })
+
+  test('return fail if input does not meet the criteria', async () => {
+    const rule = {max: {count: 3}}
+    const input = ['A', 'B', 'C', 'D']
+    const res = max.process(validatorContext, input, rule)
+    expect(res.status).toBe('fail')
+  })
 })
 
-test('return fail if input does not meet the criteria', async () => {
-  const rule = {max: {count: 3}}
-  const input = ['A', 'B', 'C', 'D']
-  const res = max.process(validatorContext, input, rule)
-  expect(res.status).toBe('fail')
+describe('max option applied to integers', () => {
+  test('return pass if input meets the criteria', async () => {
+    const rule = {max: {count: 20}}
+    let input = 10
+    let res = max.process(validatorContext, input, rule)
+    expect(res.status).toBe('pass')
+  })
+
+  test('return pass if input exactly meets criteria', async () => {
+    const rule = {max: {count: 10}}
+    const input = 10
+    const res = max.process(validatorContext, input, rule)
+    expect(res.status).toBe('pass')
+  })
+
+  test('return fail if input does not meet the criteria', async () => {
+    const rule = {max: {count: 10}}
+    const input = 20
+    const res = max.process(validatorContext, input, rule)
+    expect(res.status).toBe('fail')
+  })
 })
 
-test('return error if inputs are not in expected format', async () => {
-  const rule = {max: {regex: 3}}
-  const input = ['the test']
-  try {
-    let config = max.process(validatorContext, input, rule)
-    expect(config).toBeUndefined()
-  } catch (e) {
-    expect(e.message).toBe(`Failed to run the test because 'count' is not provided for 'max' option. Please check README for more information about configuration`)
-  }
+describe('max option configured incorrectly', () => {
+  test('return error if rule config is not in expected format', async () => {
+    const rule = {max: {regex: 3}}
+    const input = ['the test']
+    try {
+      let config = max.process(validatorContext, input, rule)
+      expect(config).toBeUndefined()
+    } catch (e) {
+      expect(e.message).toBe(`Failed to run the test because 'count' is not provided for 'max' option. Please check README for more information about configuration`)
+    }
+  })
+
+  test('return error if input is not supported type', async () => {
+    const rule = {max: {count: 3}}
+    const input = 'hello'
+    try {
+      let config = max.process(validatorContext, input, rule)
+      expect(config).toBeUndefined()
+    } catch (e) {
+      expect(e.message).toBe('Input type invalid, expected Array or Integer as input')
+    }
+  })
 })

--- a/__tests__/validators/size.test.js
+++ b/__tests__/validators/size.test.js
@@ -1,0 +1,136 @@
+const Helper = require('../../__fixtures__/helper')
+const Size = require('../../lib/validators/size')
+
+describe('PR size validator', () => {
+  const FILES = [
+    {
+      filename: 'thing.js',
+      status: 'modified',
+      additions: 10,
+      deletions: 5,
+      changes: 15
+    },
+    {
+      filename: 'another.js',
+      status: 'added',
+      additions: 3,
+      deletions: 2,
+      changes: 5
+    },
+    {
+      filename: 'removed_file_should_be_ignored.js',
+      status: 'removed',
+      additions: 0,
+      deletions: 500,
+      changes: 500
+    }
+  ]
+
+  test('fails when size above max', async () => {
+    const size = new Size()
+    const settings = {
+      do: 'size',
+      lines: {
+        max: {
+          count: 10,
+          message: 'Too big!'
+        }
+      }
+    }
+
+    let validation = await size.validate(createMockContext(FILES), settings)
+    expect(validation.status).toBe('fail')
+    expect(validation.validations[0].description).toBe('Too big!')
+  })
+
+  test('passes when changes below max', async () => {
+    const size = new Size()
+    const settings = {
+      do: 'size',
+      lines: {
+        max: {
+          count: 50,
+          message: 'Too big!'
+        }
+      }
+    }
+
+    let validation = await size.validate(createMockContext(FILES), settings)
+    expect(validation.status).toBe('pass')
+    expect(validation.validations[0].description).toBe('PR size is OK!')
+  })
+
+  test('passes when changes equal to max', async () => {
+    const size = new Size()
+    const settings = {
+      do: 'size',
+      lines: {
+        max: {
+          count: 20,
+          message: 'Too big!'
+        }
+      }
+    }
+
+    let validation = await size.validate(createMockContext(FILES), settings)
+    expect(validation.status).toBe('pass')
+    expect(validation.validations[0].description).toBe('PR size is OK!')
+  })
+
+  test('ignores specified files', async () => {
+    const size = new Size()
+    const settings = {
+      do: 'size',
+      lines: {
+        max: {
+          count: 15,
+          message: 'Too big!'
+        }
+      },
+      ignore: ['another.js']
+    }
+
+    let validation = await size.validate(createMockContext(FILES), settings)
+    expect(validation.status).toBe('pass')
+    expect(validation.validations[0].description).toBe('PR size is OK!')
+  })
+
+  test('handles empty ignore args', async () => {
+    const size = new Size()
+    let settings = {
+      do: 'size',
+      lines: {
+        max: {
+          count: 15,
+          message: 'Too big!'
+        }
+      },
+      ignore: []
+    }
+
+    let validation = await size.validate(createMockContext(FILES), settings)
+    expect(validation.status).toBe('fail')
+    expect(validation.validations[0].description).toBe('Too big!')
+
+    settings = {
+      do: 'size',
+      lines: {
+        max: {
+          count: 50,
+          message: 'Too big!'
+        }
+      },
+      ignore: []
+    }
+
+    validation = await size.validate(createMockContext(FILES), settings)
+    expect(validation.status).toBe('pass')
+    expect(validation.validations[0].description).toBe('PR size is OK!')
+  })
+})
+
+const createMockContext = (files) => {
+  return Helper.mockContext({
+    files: files
+  })
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@
   </a>
   <a href="https://circleci.com/gh/jusx/mergeable">
     <img src="https://circleci.com/gh/jusx/mergeable.svg?style=shield">
-  </a>  
+  </a>
   <a href="https://codecov.io/gh/jusx/mergeable">
     <img src="https://codecov.io/gh/jusx/mergeable/branch/master/graph/badge.svg">
   </a>
@@ -62,11 +62,11 @@ mergeable:
         {{option}}: # name of an option supported by the validator.
           {{sub-option}}: {{value}} # an option will have one or more sub-options.
     pass: # list of actions to be executed if all validation passes. Specify one or more. Omit this tag if no actions are needed.
-      - do: {{action}}   
+      - do: {{action}}
     fail: # list of actions to be executed when at least one validation fails. Specify one or more. Omit this tag if no actions are needed.
-      - do: {{action}}            
+      - do: {{action}}
     error: # list of actions to be executed when at least one validator throws an error. Specify one or more. Omit this tag if no actions are needed.
-      - do: {{action}}      
+      - do: {{action}}
 ```
 
 Take a look at some [example recipes](#examples).
@@ -127,7 +127,7 @@ Supported events:
   max:
     count: 2 # There should not be more than 2 assignees
     message: 'test string' # this is optional
-  min:  
+  min:
     count: 2 # min number of assignees
     message: 'test string' # this is optional
 ```
@@ -184,7 +184,7 @@ The above will validate that both the files `package-lock.json` and `yarn.lock` 
        message: 'Some message...' #optional
     ends_with:
        match: 'Any last sentence' # array of strings
-       message: 'Come message...' # optional    
+       message: 'Come message...' # optional
 ```
 Supported events:
 
@@ -211,7 +211,7 @@ Supported events:
     ends_with:
        match: 'A String' # or array of strings
        message: 'Come message...'
-    # all of the message sub-option is optional   
+    # all of the message sub-option is optional
 ```
 Supported events:
 
@@ -238,7 +238,7 @@ Supported events:
   ends_with:
      match: 'A String' # array list of strings
      message: 'Come message...'
-  # all of the message sub-option is optional   
+  # all of the message sub-option is optional
 ```
 > ☝ **NOTE:** When a [closing keyword](https://help.github.com/articles/closing-issues-using-keywords/) is used in the description of a pull request. The annotated issue will be validated against the conditions as well.
 
@@ -306,12 +306,12 @@ Supported events:
      regex: 'DO NOT MERGE|WIP'
      message: 'Custom message...'
   begins_with:
-     match: ['doc','feat','fix','chore']  
+     match: ['doc','feat','fix','chore']
      message: 'Some message...'
   ends_with:
      match: 'A String' # or array of strings
      message: 'Come message...'
-     # all of the message sub-option is optional   
+     # all of the message sub-option is optional
 ```
 
 ### Advanced Logic
@@ -325,7 +325,7 @@ Validators can be grouped together with `AND` and `OR` operators:
         message: 'Test plan must be included'
     - must_include:
         regex: 'Goal'
-        message: 'Please include the goal of the PR'                 
+        message: 'Please include the goal of the PR'
 ```
 
 `AND` and `OR` operators can also be nested
@@ -462,7 +462,31 @@ Validate pull requests for mergeability based on content and structure of your P
   ```
   </p>
 </details>
+<br>
 
+**Size**: Ensure that PRs don't exceed a certain size (in terms of lines changed). Currently this just
+checks the combined total of additions and deletions across all files that were added or modified.
+It ignores files that were completely deleted. You can specify a list of files to
+ignore with `ignore`.
+
+<details><summary>🔖 See Recipe</summary>
+  <p>
+
+  ```yml
+  version: 2
+  mergeable:
+    - when: pull_request.*
+      validate:
+        - do: size
+          ignore: ['ignore_me.js']
+          lines:
+            max:
+              count: 500
+              message: Change is very large. Should be under 500 lines of addtions and deletions.
+  ```
+  </p>
+</details>
+<br>
 <!-- **Projects**: Ensure that all Pull Requests have a Project associated. Mergeable will also detect when you are [closing an issue](https://help.github.com/articles/closing-issues-using-keywords/) that is associated with the specified project. Useful when you want to make sure all issues and pull requests merged are visible on a [project board](https://help.github.com/articles/about-project-boards/).
 <details><summary>🔖 See Recipe</summary>
   <p>

--- a/lib/validators/options_processor/options/max.js
+++ b/lib/validators/options_processor/options/max.js
@@ -1,5 +1,5 @@
 const COUNT_NOT_FOUND_ERROR = `Failed to run the test because 'count' is not provided for 'max' option. Please check README for more information about configuration`
-const UNKNOWN_INPUT_TYPE_ERROR = `Input type invalid, expected Array as input`
+const UNKNOWN_INPUT_TYPE_ERROR = `Input type invalid, expected Array or Integer as input`
 
 class Max {
   static process (validatorContext, input, rule) {
@@ -17,7 +17,9 @@ class Max {
     if (!description) description = `${validatorContext.name} count is more than "${count}"`
 
     if (Array.isArray(input)) {
-      isMergeable = !(input.length > count)
+      isMergeable = input.length <= count
+    } else if (Number.isInteger(input)) {
+      isMergeable = input <= count
     } else {
       throw new Error(UNKNOWN_INPUT_TYPE_ERROR)
     }

--- a/lib/validators/size.js
+++ b/lib/validators/size.js
@@ -1,0 +1,95 @@
+const { Validator } = require('./validator')
+const constructOutput = require('./options_processor/options/lib/constructOutput')
+const consolidateResult = require('./options_processor/options/lib/consolidateResults')
+const constructErrorOutput = require('./options_processor/options/lib/constructErrorOutput')
+
+class Size extends Validator {
+  constructor () {
+    super()
+    this.supportedEvents = [
+      'pull_request.opened',
+      'pull_request.edited',
+      'pull_request_review.submitted',
+      'pull_request_review.edited',
+      'pull_request_review.dismissed',
+      'pull_request.labeled',
+      'pull_request.milestoned',
+      'pull_request.demilestoned',
+      'pull_request.assigned',
+      'pull_request.unassigned',
+      'pull_request.unlabeled',
+      'pull_request.synchronize'
+    ]
+    this.supportedOptions = ['max']
+  }
+
+  async validate (context, validationSettings) {
+    const ERROR_MESSAGE = `Failed to validate because the 'lines' or 'max' option is missing. Please check the documentation.`
+    const VALIDATOR_NAME = 'Size'
+    const validatorContext = {name: VALIDATOR_NAME}
+
+    const payload = this.getPayload(context)
+    const filesToIgnore = validationSettings.ignore || []
+    const getFilesResult = await context.github.pullRequests.getFiles(
+      context.repo({number: payload.number})
+    )
+
+    // Possible file statuses: addded, modified, removed.
+    const modifiedFiles = getFilesResult.data
+      .filter(file => !filesToIgnore.includes(file.filename))
+      .filter(file => file.status === 'modified' || file.status === 'added')
+      .map(
+        file => ({
+          filename: file.filename,
+          additions: file.additions,
+          deletions: file.deletions,
+          changes: file.changes
+        })
+      )
+
+    let additions = 0
+    let deletions = 0
+    let totalChanges = 0
+
+    modifiedFiles.forEach((file) => {
+      additions += file.additions
+      deletions += file.deletions
+      totalChanges += file.changes
+    })
+
+    const inputMessage = `${totalChanges} (${additions} additions, ${deletions} deletions)`
+
+    if (!validationSettings.lines || !validationSettings.lines.max) {
+      return consolidateResult(
+        [
+          constructErrorOutput(
+            VALIDATOR_NAME,
+            inputMessage,
+            validationSettings,
+            ERROR_MESSAGE
+          )
+        ],
+        validatorContext
+      )
+    }
+
+    const isMergeable = totalChanges <= validationSettings.lines.max.count
+    const defaultFailMessage = `PR is too large. Should be under ${validationSettings.lines.max.count} total additions + deletions`
+    const result = {
+      status: isMergeable ? 'pass' : 'fail',
+      description: isMergeable
+        ? 'PR size is OK!'
+        : validationSettings.lines.max.message || defaultFailMessage
+    }
+    const output = constructOutput(
+      validatorContext,
+      inputMessage,
+      validationSettings,
+      result
+    )
+
+    return consolidateResult([output], validatorContext)
+  }
+}
+
+module.exports = Size


### PR DESCRIPTION
Hi, I noticed that in the README there was mention of adding a way to validate the size of PRs. This sounded like a useful feature, and is something I was interested in using the bot for at my work.

This PR is my attempt at adding this. I've tested it out locally, and it seems to work OK.

I'm still not very familiar with the codebase, so this might not be the right way to approach this - let me know what you think.

It's also quite simple at the moment: it only lets you specify a maximum size for the total, and only counts added or modified files. Let me know if you'd prefer it to be more flexible or if this is OK as a start (it should be fairly easy to change the behavior either way).

Apologies for the (ironically) somewhat large PR. I've tried to keep it small, but there are a couple of tiny fixes/refactors I can take out if you'd prefer to make this smaller.

Screenshot of local test run:
![failure_screenshot](https://user-images.githubusercontent.com/2632211/55278385-81406880-5303-11e9-8d90-539b5fab8c1d.png)

Full description of changes from the commit:

> Adds a new `size` validator that allows for validating the size of PRs
> in terms of changes. Currently, this only lets you validate that the
> total no. of changed lines is below a maximum using the `max` option.
> 
> It also supports an `ignore` setting to allow excluding certain files
> from the total size (e.g. for ignoring automatically generated files
> that increase the size a lot).
> 
> Things it does not support but could be added in future:
>   - Using different options than `max`
>   - Validating additions and deletions separately (e.g allowing 300
>     additions max, 600 deletions max)
>   - Including entirely deleted files in the total (can very easily be
>     added)
> 
> Other changes that were needed to get this working:
>   - Update `max` option to support integers as well as Arrays
