### PR TITLE
docs: Small fix to size validator example in README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -170,7 +170,7 @@ changed lines is below a certain amount using the `max` option:
     lines:
       max:
         count: 500
-        message: Change is very large. Should be under 10 lines of addtions and deletions.
+        message: Change is very large. Should be under 500 lines of addtions and deletions.
 ```
 
 It also supports an `ignore` setting to allow excluding certain files from the
@@ -183,7 +183,7 @@ size a lot):
     lines:
       max:
         count: 500
-        message: Change is very large. Should be under 10 lines of addtions and deletions.
+        message: Change is very large. Should be under 500 lines of addtions and deletions.
 ```
 
 The `size` validator currently excludes from the size count any files that were


### PR DESCRIPTION
The example had a message that didn't quite match the config setting,  which could be confusing.